### PR TITLE
Use https so the wizard sample loads in modern browsers.

### DIFF
--- a/styledmaps/wizard/StyledMapWizard.js
+++ b/styledmaps/wizard/StyledMapWizard.js
@@ -822,7 +822,7 @@ function closeStaticMap() {
 }
 
 function getStaticMapsURL() {
-  var url = 'http://maps.googleapis.com/maps/api/staticmap?';
+  var url = 'https://maps.googleapis.com/maps/api/staticmap?';
   var params = [];
   params.push('center=' + map.getCenter().toUrlValue());
   params.push('zoom=' + map.getZoom());

--- a/styledmaps/wizard/index.html
+++ b/styledmaps/wizard/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Google Maps API Styled Map Wizard</title>
     <link rel="stylesheet" type="text/css" href="StyledMapWizard.css"></link>
-    <script src="http://maps.google.com/maps/api/js?libraries=places&key=AIzaSyA4rAT0fdTZLNkJ5o0uaAwZ89vVPQpr_Kc"></script>
+    <script src="https://maps.google.com/maps/api/js?libraries=places&key=AIzaSyA4rAT0fdTZLNkJ5o0uaAwZ89vVPQpr_Kc"></script>
     <script src="StyledMapWizard.js"></script>
   </head>
   <body onload="init()">


### PR DESCRIPTION
This is necessary to prevent the following error:
`Mixed Content: The page at 'https://googlemaps.github.io/js-samples/styledmaps/wizard/index.html' was loaded over HTTPS, but requested an insecure script 'http://maps.google.com/maps/api/js?libraries=places&key=AIzaSyA4rAT0fdTZLNkJ5o0uaAwZ89vVPQpr_Kc'. This request has been blocked; the content must be served over HTTPS.`

There are other places that probably should be updated as well.