### PR TITLE
fix: hardcode key in templates

### DIFF
--- a/shared/context.njk
+++ b/shared/context.njk
@@ -1,0 +1,1 @@
+{% set key = 'AIzaSyCMS6fbxgR56yYaWGcvelt7xcipr4j-hMY'%}

--- a/shared/layout.njk
+++ b/shared/layout.njk
@@ -14,9 +14,12 @@
   limitations under the License.
 -->
 
+{# path of include must be from root template context #}
+{% include "shared/context.njk" %}
+
 {% macro api() %}
   <script 
-    src="https://maps.googleapis.com/maps/api/js?key={{ env.GOOGLE_MAPS_KEY }}&callback={{ callback }}&libraries={{ libraries }}&version={{ version }}" 
+    src="https://maps.googleapis.com/maps/api/js?key={{ key }}&callback={{ callback }}&libraries={{ libraries }}&version={{ version }}" 
     async defer></script>
 {% endmacro %}
 


### PR DESCRIPTION
it is incredibly difficult to use an environment variable here due to the Bazel sandbox