### PR TITLE
build: use mode on nunjucks macro

### DIFF
--- a/rules/nunjucks.bzl
+++ b/rules/nunjucks.bzl
@@ -1,13 +1,12 @@
-
-def nunjucks(name, outs, template, json, data):
+def nunjucks(name, outs, template, json, data, mode):
     # this genrule moves the generated html file to the correct location
     # nunjucks-cli does not allow specifying a single output file
     # nunjucks-cli converts the .njk to a .html by default
     native.genrule(
         name = name,
         srcs = data,
-        tools = ["//rules:nunjucks", "//rules:nunjucks-cli"],
-        cmd = "$(location //rules:nunjucks) $(location {template}) $(location {json}) $(location //rules:nunjucks-cli) $@".format(template = template, json = json),
+        tools = ["//rules:nunjucks", "//rules:nunjucks-cli", "//rules:json"],
+        cmd = "$(location //rules:nunjucks) $(location {template}) $(location {json}) $(location //rules:nunjucks-cli) {mode} $@".format(template = template, json = json, mode = mode),
         outs = outs,
         visibility = ["//visibility:public"],
     )

--- a/rules/nunjucks.sh
+++ b/rules/nunjucks.sh
@@ -2,11 +2,15 @@
 
 set -e
 tmp=$(mktemp -d)
+context=$(mktemp)
 
 template=$1
 json=$2
 nunjucks=$3
-destination=$4
+mode=$4
+destination=$5
 
-$nunjucks "$template" -p . "$json" --out "$tmp"
+bazel-out/host/bin/rules/json.sh -f "$json" -e "this.mode=\"$mode\"" > "$context"
+
+$nunjucks "$template" -p . "$context" --out "$tmp"
 cat "$tmp/${template//njk/html}" > "$destination"

--- a/shared/layout.njk
+++ b/shared/layout.njk
@@ -14,15 +14,11 @@
         defer></script>
     {% endblock %}
     <!-- [END maps_{{tag}}_htmll_head_api] -->
-    {% if jsfiddle %}
+    {% if mode == "jsfiddle" %}
       <!-- jsFiddle will insert css and js -->
     {% else %}
-      {% block css %}
-        <link rel="stylesheet" type="text/css" href="./style.css" data-inline>
-      {% endblock %}
-      {% block js %}
-        <script src="./app.js" data-inline></script>
-      {% endblock %}
+      <link rel="stylesheet" type="text/css" href="./style.css" data-inline>
+      <script src="./app.js" data-inline></script>
     {% endif %}
   </head>
   <body>


### PR DESCRIPTION
This simplifies the build to avoid modifiying and storing an intermediate data.json for each sample.