### PR TITLE
feat: change babel options for inline sample output and jsfiddle js

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,7 +8,7 @@ exports_files(
         "LICENSE",
         "package.json",
         "rollup.config.js",
-        ".babelrc",
+        "rollup.config.iframe.js",
         "jest.config.js",
     ],
     visibility = ["//:__subpackages__"],

--- a/README.md
+++ b/README.md
@@ -35,19 +35,20 @@ Samples for the Google Maps JavaScript API.
 
 The following table identifies the inputs and outputs.
 
-| File                          | Edit | Description                                        |     |
-| ----------------------------- | ---- | -------------------------------------------------- | --- |
-| samples/\*/src/index.js       | Y    | JavaScript for sample                              |
-| samples/\*/src/index.njk      | Y    | HTML template for sample                           |
-| samples/\*/src/style.scss     | Y    | SCSS style for sample                              |
-| shared/layout.njk             | Y    | Shared HTML template to extend                     |
-| shared/scss/\*                | Y    | Shared SCSS styles                                 |
-| dist/samples/\*/app.js        | N    | Transpiled JS                                      |
-| dist/samples/\*/index.html    | N    | Inline HTML, CSS, JS with development key          |
-| dist/samples/\*/iframe.html    | N    | Inline HTML, CSS, JS for iframe without html, head, body tags       |
-| dist/samples/\*/jsfiddle.html | N    | HTML without CSS or JS                             |
-| dist/samples/\*/sample.html   | N    | HTML without CSS or JS with template var for key   |
-| dist/samples/\*/style.css     | N    | CSS output from SCSS                               |
+| File                          | Edit | jsFiddle | Description                                                                                     |
+| ----------------------------- | ---- | -------- | ----------------------------------------------------------------------------------------------- |
+| samples/\*/src/index.js       | Y    | N        | JavaScript for sample for *JS* tab                                                              |
+| samples/\*/src/index.njk      | Y    | N        | HTML template for sample                                                                        |
+| samples/\*/src/style.scss     | Y    | N        | SCSS style for sample                                                                           |
+| shared/layout.njk             | Y    | N        | Shared HTML template to extend                                                                  |
+| shared/scss/\*                | Y    | N        | Shared SCSS styles                                                                              |
+| dist/samples/\*/app.js        | N    | Y        | Transpiled JS for >3%                                                                           | 
+| dist/samples/\*/index.html    | N    | N        | Inline HTML, CSS, JS with development key and transpiled for >1%, ie11                          |
+| dist/samples/\*/iframe.html   | N    | N        | Inline HTML, CSS, JS for iframe without html, head, body tags transpiled for ie11 and >1%, ie11 |
+| dist/samples/\*/inline.html   | N    | N        | Inline HTML, CSS, JS for *All* tab transpiled for >3%                                           |
+| dist/samples/\*/jsfiddle.html | N    | Y        | HTML without CSS or JS for in jsFiddle                                                          |
+| dist/samples/\*/sample.html   | N    | N        | HTML without CSS or JS for *HTML* tab                                                           |
+| dist/samples/\*/style.css     | N    | Y        | CSS output from SCSS for *CSS* tab                                                              |
 
 ## Other Resources
 

--- a/dist/samples/deckgl-points/app.js
+++ b/dist/samples/deckgl-points/app.js
@@ -4,14 +4,14 @@
   /* eslint-disable no-undef */
   // Initialize and add the map
   function initMap() {
-    var map = new google.maps.Map(document.getElementById("map"), {
+    const map = new google.maps.Map(document.getElementById("map"), {
       center: {
         lat: 40,
         lng: -110
       },
       zoom: 4
     });
-    var deckOverlay = new deck.GoogleMapsOverlay({
+    const deckOverlay = new deck.GoogleMapsOverlay({
       layers: [
         new deck.GeoJsonLayer({
           id: "earthquakes",
@@ -22,9 +22,7 @@
           pointRadiusMaxPixels: 200,
           opacity: 0.4,
           pointRadiusScale: 0.3,
-          getRadius: function getRadius(f) {
-            return Math.pow(10, f.properties.mag);
-          },
+          getRadius: f => Math.pow(10, f.properties.mag),
           getFillColor: [255, 70, 30, 180],
           autoHighlight: true,
           transitions: {
@@ -32,14 +30,12 @@
               type: "spring",
               stiffness: 0.1,
               damping: 0.15,
-              enter: function enter(_) {
-                return [0];
-              },
+              enter: _ => [0],
               // grow from size 0,
               duration: 10000
             }
           },
-          onDataLoad: function onDataLoad(_) {
+          onDataLoad: _ => {
             progress.done(); // hides progress bar
           }
         })

--- a/dist/samples/deckgl-points/inline.html
+++ b/dist/samples/deckgl-points/inline.html
@@ -49,14 +49,14 @@
         /* eslint-disable no-undef */
         // Initialize and add the map
         function initMap() {
-          var map = new google.maps.Map(document.getElementById("map"), {
+          const map = new google.maps.Map(document.getElementById("map"), {
             center: {
               lat: 40,
               lng: -110
             },
             zoom: 4
           });
-          var deckOverlay = new deck.GoogleMapsOverlay({
+          const deckOverlay = new deck.GoogleMapsOverlay({
             layers: [
               new deck.GeoJsonLayer({
                 id: "earthquakes",
@@ -67,9 +67,7 @@
                 pointRadiusMaxPixels: 200,
                 opacity: 0.4,
                 pointRadiusScale: 0.3,
-                getRadius: function getRadius(f) {
-                  return Math.pow(10, f.properties.mag);
-                },
+                getRadius: f => Math.pow(10, f.properties.mag),
                 getFillColor: [255, 70, 30, 180],
                 autoHighlight: true,
                 transitions: {
@@ -77,14 +75,12 @@
                     type: "spring",
                     stiffness: 0.1,
                     damping: 0.15,
-                    enter: function enter(_) {
-                      return [0];
-                    },
+                    enter: _ => [0],
                     // grow from size 0,
                     duration: 10000
                   }
                 },
-                onDataLoad: function onDataLoad(_) {
+                onDataLoad: _ => {
                   progress.done(); // hides progress bar
                 }
               })

--- a/dist/samples/directions-complex/app.js
+++ b/dist/samples/directions-complex/app.js
@@ -28,7 +28,7 @@
       map
     ); // Listen to change events from the start and end lists.
 
-    var onChangeHandler = function onChangeHandler() {
+    var onChangeHandler = function() {
       calculateAndDisplayRoute(
         directionsRenderer,
         directionsService,

--- a/dist/samples/directions-complex/inline.html
+++ b/dist/samples/directions-complex/inline.html
@@ -73,7 +73,7 @@
             map
           ); // Listen to change events from the start and end lists.
 
-          var onChangeHandler = function onChangeHandler() {
+          var onChangeHandler = function() {
             calculateAndDisplayRoute(
               directionsRenderer,
               directionsService,

--- a/dist/samples/directions-panel/app.js
+++ b/dist/samples/directions-panel/app.js
@@ -17,7 +17,7 @@
     control.style.display = "block";
     map.controls[google.maps.ControlPosition.TOP_CENTER].push(control);
 
-    var onChangeHandler = function onChangeHandler() {
+    var onChangeHandler = function() {
       calculateAndDisplayRoute(directionsService, directionsRenderer);
     };
 

--- a/dist/samples/directions-panel/inline.html
+++ b/dist/samples/directions-panel/inline.html
@@ -108,7 +108,7 @@
           control.style.display = "block";
           map.controls[google.maps.ControlPosition.TOP_CENTER].push(control);
 
-          var onChangeHandler = function onChangeHandler() {
+          var onChangeHandler = function() {
             calculateAndDisplayRoute(directionsService, directionsRenderer);
           };
 

--- a/dist/samples/directions-simple/app.js
+++ b/dist/samples/directions-simple/app.js
@@ -13,7 +13,7 @@
     });
     directionsRenderer.setMap(map);
 
-    var onChangeHandler = function onChangeHandler() {
+    var onChangeHandler = function() {
       calculateAndDisplayRoute(directionsService, directionsRenderer);
     };
 

--- a/dist/samples/directions-simple/inline.html
+++ b/dist/samples/directions-simple/inline.html
@@ -52,7 +52,7 @@
           });
           directionsRenderer.setMap(map);
 
-          var onChangeHandler = function onChangeHandler() {
+          var onChangeHandler = function() {
             calculateAndDisplayRoute(directionsService, directionsRenderer);
           };
 

--- a/dist/samples/event-poi/app.js
+++ b/dist/samples/event-poi/app.js
@@ -16,7 +16,7 @@
    * @constructor
    */
 
-  var ClickEventHandler = function ClickEventHandler(map, origin) {
+  var ClickEventHandler = function(map, origin) {
     this.origin = origin;
     this.map = map;
     this.directionsService = new google.maps.DirectionsService();

--- a/dist/samples/event-poi/inline.html
+++ b/dist/samples/event-poi/inline.html
@@ -53,7 +53,7 @@
          * @constructor
          */
 
-        var ClickEventHandler = function ClickEventHandler(map, origin) {
+        var ClickEventHandler = function(map, origin) {
           this.origin = origin;
           this.map = map;
           this.directionsService = new google.maps.DirectionsService();

--- a/dist/samples/map-projection-simple/app.js
+++ b/dist/samples/map-projection-simple/app.js
@@ -43,7 +43,7 @@
     var GALL_PETERS_RANGE_Y = 512; // Fetch Gall-Peters tiles stored locally on our server.
 
     exports.gallPetersMapType = new google.maps.ImageMapType({
-      getTileUrl: function getTileUrl(coord, zoom) {
+      getTileUrl: function(coord, zoom) {
         var scale = 1 << zoom; // Wrap tiles horizontally.
 
         var x = ((coord.x % scale) + scale) % scale; // Don't wrap tiles vertically.
@@ -68,14 +68,14 @@
     }); // Describe the Gall-Peters projection used by these tiles.
 
     exports.gallPetersMapType.projection = {
-      fromLatLngToPoint: function fromLatLngToPoint(latLng) {
+      fromLatLngToPoint: function(latLng) {
         var latRadians = (latLng.lat() * Math.PI) / 180;
         return new google.maps.Point(
           GALL_PETERS_RANGE_X * (0.5 + latLng.lng() / 360),
           GALL_PETERS_RANGE_Y * (0.5 - 0.5 * Math.sin(latRadians))
         );
       },
-      fromPointToLatLng: function fromPointToLatLng(point, noWrap) {
+      fromPointToLatLng: function(point, noWrap) {
         var x = point.x / GALL_PETERS_RANGE_X;
         var y = Math.max(0, Math.min(1, point.y / GALL_PETERS_RANGE_Y));
         return new google.maps.LatLng(

--- a/dist/samples/map-projection-simple/inline.html
+++ b/dist/samples/map-projection-simple/inline.html
@@ -74,7 +74,7 @@
           var GALL_PETERS_RANGE_Y = 512; // Fetch Gall-Peters tiles stored locally on our server.
 
           exports.gallPetersMapType = new google.maps.ImageMapType({
-            getTileUrl: function getTileUrl(coord, zoom) {
+            getTileUrl: function(coord, zoom) {
               var scale = 1 << zoom; // Wrap tiles horizontally.
 
               var x = ((coord.x % scale) + scale) % scale; // Don't wrap tiles vertically.
@@ -102,14 +102,14 @@
           }); // Describe the Gall-Peters projection used by these tiles.
 
           exports.gallPetersMapType.projection = {
-            fromLatLngToPoint: function fromLatLngToPoint(latLng) {
+            fromLatLngToPoint: function(latLng) {
               var latRadians = (latLng.lat() * Math.PI) / 180;
               return new google.maps.Point(
                 GALL_PETERS_RANGE_X * (0.5 + latLng.lng() / 360),
                 GALL_PETERS_RANGE_Y * (0.5 - 0.5 * Math.sin(latRadians))
               );
             },
-            fromPointToLatLng: function fromPointToLatLng(point, noWrap) {
+            fromPointToLatLng: function(point, noWrap) {
               var x = point.x / GALL_PETERS_RANGE_X;
               var y = Math.max(0, Math.min(1, point.y / GALL_PETERS_RANGE_Y));
               return new google.maps.LatLng(

--- a/dist/samples/maptype-image-overlay/app.js
+++ b/dist/samples/maptype-image-overlay/app.js
@@ -28,7 +28,7 @@
       ]
     };
     var imageMapType = new google.maps.ImageMapType({
-      getTileUrl: function getTileUrl(coord, zoom) {
+      getTileUrl: function(coord, zoom) {
         if (
           zoom < 17 ||
           zoom > 20 ||

--- a/dist/samples/maptype-image-overlay/inline.html
+++ b/dist/samples/maptype-image-overlay/inline.html
@@ -53,7 +53,7 @@
             ]
           };
           var imageMapType = new google.maps.ImageMapType({
-            getTileUrl: function getTileUrl(coord, zoom) {
+            getTileUrl: function(coord, zoom) {
               if (
                 zoom < 17 ||
                 zoom > 20 ||

--- a/dist/samples/maptype-image/app.js
+++ b/dist/samples/maptype-image/app.js
@@ -14,7 +14,7 @@
       }
     });
     var moonMapType = new google.maps.ImageMapType({
-      getTileUrl: function getTileUrl(coord, zoom) {
+      getTileUrl: function(coord, zoom) {
         var normalizedCoord = getNormalizedCoord(coord, zoom);
 
         if (!normalizedCoord) {

--- a/dist/samples/maptype-image/inline.html
+++ b/dist/samples/maptype-image/inline.html
@@ -39,7 +39,7 @@
             }
           });
           var moonMapType = new google.maps.ImageMapType({
-            getTileUrl: function getTileUrl(coord, zoom) {
+            getTileUrl: function(coord, zoom) {
               var normalizedCoord = getNormalizedCoord(coord, zoom);
 
               if (!normalizedCoord) {

--- a/dist/samples/places-queryprediction/app.js
+++ b/dist/samples/places-queryprediction/app.js
@@ -7,7 +7,7 @@
   // parameter when you first load the API. For example:
   // <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&libraries=places">
   function initService() {
-    var displaySuggestions = function displaySuggestions(predictions, status) {
+    var displaySuggestions = function(predictions, status) {
       if (status != google.maps.places.PlacesServiceStatus.OK) {
         alert(status);
         return;

--- a/dist/samples/places-queryprediction/inline.html
+++ b/dist/samples/places-queryprediction/inline.html
@@ -51,10 +51,7 @@
         // parameter when you first load the API. For example:
         // <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&libraries=places">
         function initService() {
-          var displaySuggestions = function displaySuggestions(
-            predictions,
-            status
-          ) {
+          var displaySuggestions = function(predictions, status) {
             if (status != google.maps.places.PlacesServiceStatus.OK) {
               alert(status);
               return;

--- a/dist/samples/split-map-panes/app.js
+++ b/dist/samples/split-map-panes/app.js
@@ -1,65 +1,8 @@
 (function(exports) {
   "use strict";
 
-  function _defineProperty(obj, key, value) {
-    if (key in obj) {
-      Object.defineProperty(obj, key, {
-        value: value,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    } else {
-      obj[key] = value;
-    }
-
-    return obj;
-  }
-
-  function ownKeys(object, enumerableOnly) {
-    var keys = Object.keys(object);
-
-    if (Object.getOwnPropertySymbols) {
-      var symbols = Object.getOwnPropertySymbols(object);
-      if (enumerableOnly)
-        symbols = symbols.filter(function(sym) {
-          return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-        });
-      keys.push.apply(keys, symbols);
-    }
-
-    return keys;
-  }
-
-  function _objectSpread2(target) {
-    for (var i = 1; i < arguments.length; i++) {
-      var source = arguments[i] != null ? arguments[i] : {};
-
-      if (i % 2) {
-        ownKeys(Object(source), true).forEach(function(key) {
-          _defineProperty(target, key, source[key]);
-        });
-      } else if (Object.getOwnPropertyDescriptors) {
-        Object.defineProperties(
-          target,
-          Object.getOwnPropertyDescriptors(source)
-        );
-      } else {
-        ownKeys(Object(source)).forEach(function(key) {
-          Object.defineProperty(
-            target,
-            key,
-            Object.getOwnPropertyDescriptor(source, key)
-          );
-        });
-      }
-    }
-
-    return target;
-  }
-
   function initMap() {
-    var mapOptions = {
+    const mapOptions = {
       center: {
         lat: 44.5250489,
         lng: -110.83819
@@ -69,60 +12,43 @@
       streetViewControl: false
     }; // instantiate the map on the left with control positioning
 
-    exports.mapLeft = new google.maps.Map(
-      document.getElementById("map-left"),
-      _objectSpread2(
-        _objectSpread2({}, mapOptions),
-        {},
-        {
-          mapTypeId: "satellite",
-          tilt: 0,
-          // at high zoom levels we need to maintain the same projection
-          fullscreenControlOptions: {
-            position: google.maps.ControlPosition.LEFT_BOTTOM
-          },
-          mapTypeControlOptions: {
-            position: google.maps.ControlPosition.LEFT_TOP
-          },
-          zoomControlOptions: {
-            position: google.maps.ControlPosition.LEFT_BOTTOM
-          }
-        }
-      )
-    ); // instantiate the map on the right with control positioning
+    exports.mapLeft = new google.maps.Map(document.getElementById("map-left"), {
+      ...mapOptions,
+      mapTypeId: "satellite",
+      tilt: 0,
+      // at high zoom levels we need to maintain the same projection
+      fullscreenControlOptions: {
+        position: google.maps.ControlPosition.LEFT_BOTTOM
+      },
+      mapTypeControlOptions: {
+        position: google.maps.ControlPosition.LEFT_TOP
+      },
+      zoomControlOptions: {
+        position: google.maps.ControlPosition.LEFT_BOTTOM
+      }
+    }); // instantiate the map on the right with control positioning
 
     exports.mapRight = new google.maps.Map(
       document.getElementById("map-right"),
-      _objectSpread2(
-        _objectSpread2({}, mapOptions),
-        {},
-        {
-          fullscreenControlOptions: {
-            position: google.maps.ControlPosition.RIGHT_BOTTOM
-          },
-          mapTypeControlOptions: {
-            position: google.maps.ControlPosition.RIGHT_TOP
-          },
-          zoomControlOptions: {
-            position: google.maps.ControlPosition.RIGHT_BOTTOM
-          }
+      {
+        ...mapOptions,
+        fullscreenControlOptions: {
+          position: google.maps.ControlPosition.RIGHT_BOTTOM
+        },
+        mapTypeControlOptions: {
+          position: google.maps.ControlPosition.RIGHT_TOP
+        },
+        zoomControlOptions: {
+          position: google.maps.ControlPosition.RIGHT_BOTTOM
         }
-      )
+      }
     ); // helper function to keep maps in sync
 
-    function sync() {
-      for (
-        var _len = arguments.length, maps = new Array(_len), _key = 0;
-        _key < _len;
-        _key++
-      ) {
-        maps[_key] = arguments[_key];
-      }
-
-      var center, zoom;
+    function sync(...maps) {
+      let center, zoom;
 
       function update(ignore) {
-        maps.forEach(function(m) {
+        maps.forEach(m => {
           if (m === ignore) {
             return;
           }
@@ -132,10 +58,10 @@
         });
       }
 
-      maps.forEach(function(m) {
-        m.addListener("bounds_changed", function() {
-          var changedCenter = m.getCenter();
-          var changedZoom = m.getZoom();
+      maps.forEach(m => {
+        m.addListener("bounds_changed", () => {
+          const changedCenter = m.getCenter();
+          const changedZoom = m.getZoom();
 
           if (changedCenter !== center || changedZoom !== zoom) {
             center = changedCenter;
@@ -149,10 +75,10 @@
     sync(exports.mapLeft, exports.mapRight);
 
     function handleContainerResize() {
-      var width = document.getElementById("container").offsetWidth;
+      const width = document.getElementById("container").offsetWidth;
       console.log(width);
-      document.getElementById("map-left").style.width = "".concat(width, "px");
-      document.getElementById("map-right").style.width = "".concat(width, "px");
+      document.getElementById("map-left").style.width = `${width}px`;
+      document.getElementById("map-right").style.width = `${width}px`;
     } // trigger to set map container size since using absolute
 
     handleContainerResize(); // add event listener

--- a/dist/samples/split-map-panes/inline.html
+++ b/dist/samples/split-map-panes/inline.html
@@ -66,65 +66,8 @@
       (function(exports) {
         "use strict";
 
-        function _defineProperty(obj, key, value) {
-          if (key in obj) {
-            Object.defineProperty(obj, key, {
-              value: value,
-              enumerable: true,
-              configurable: true,
-              writable: true
-            });
-          } else {
-            obj[key] = value;
-          }
-
-          return obj;
-        }
-
-        function ownKeys(object, enumerableOnly) {
-          var keys = Object.keys(object);
-
-          if (Object.getOwnPropertySymbols) {
-            var symbols = Object.getOwnPropertySymbols(object);
-            if (enumerableOnly)
-              symbols = symbols.filter(function(sym) {
-                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-              });
-            keys.push.apply(keys, symbols);
-          }
-
-          return keys;
-        }
-
-        function _objectSpread2(target) {
-          for (var i = 1; i < arguments.length; i++) {
-            var source = arguments[i] != null ? arguments[i] : {};
-
-            if (i % 2) {
-              ownKeys(Object(source), true).forEach(function(key) {
-                _defineProperty(target, key, source[key]);
-              });
-            } else if (Object.getOwnPropertyDescriptors) {
-              Object.defineProperties(
-                target,
-                Object.getOwnPropertyDescriptors(source)
-              );
-            } else {
-              ownKeys(Object(source)).forEach(function(key) {
-                Object.defineProperty(
-                  target,
-                  key,
-                  Object.getOwnPropertyDescriptor(source, key)
-                );
-              });
-            }
-          }
-
-          return target;
-        }
-
         function initMap() {
-          var mapOptions = {
+          const mapOptions = {
             center: {
               lat: 44.5250489,
               lng: -110.83819
@@ -136,58 +79,44 @@
 
           exports.mapLeft = new google.maps.Map(
             document.getElementById("map-left"),
-            _objectSpread2(
-              _objectSpread2({}, mapOptions),
-              {},
-              {
-                mapTypeId: "satellite",
-                tilt: 0,
-                // at high zoom levels we need to maintain the same projection
-                fullscreenControlOptions: {
-                  position: google.maps.ControlPosition.LEFT_BOTTOM
-                },
-                mapTypeControlOptions: {
-                  position: google.maps.ControlPosition.LEFT_TOP
-                },
-                zoomControlOptions: {
-                  position: google.maps.ControlPosition.LEFT_BOTTOM
-                }
+            {
+              ...mapOptions,
+              mapTypeId: "satellite",
+              tilt: 0,
+              // at high zoom levels we need to maintain the same projection
+              fullscreenControlOptions: {
+                position: google.maps.ControlPosition.LEFT_BOTTOM
+              },
+              mapTypeControlOptions: {
+                position: google.maps.ControlPosition.LEFT_TOP
+              },
+              zoomControlOptions: {
+                position: google.maps.ControlPosition.LEFT_BOTTOM
               }
-            )
+            }
           ); // instantiate the map on the right with control positioning
 
           exports.mapRight = new google.maps.Map(
             document.getElementById("map-right"),
-            _objectSpread2(
-              _objectSpread2({}, mapOptions),
-              {},
-              {
-                fullscreenControlOptions: {
-                  position: google.maps.ControlPosition.RIGHT_BOTTOM
-                },
-                mapTypeControlOptions: {
-                  position: google.maps.ControlPosition.RIGHT_TOP
-                },
-                zoomControlOptions: {
-                  position: google.maps.ControlPosition.RIGHT_BOTTOM
-                }
+            {
+              ...mapOptions,
+              fullscreenControlOptions: {
+                position: google.maps.ControlPosition.RIGHT_BOTTOM
+              },
+              mapTypeControlOptions: {
+                position: google.maps.ControlPosition.RIGHT_TOP
+              },
+              zoomControlOptions: {
+                position: google.maps.ControlPosition.RIGHT_BOTTOM
               }
-            )
+            }
           ); // helper function to keep maps in sync
 
-          function sync() {
-            for (
-              var _len = arguments.length, maps = new Array(_len), _key = 0;
-              _key < _len;
-              _key++
-            ) {
-              maps[_key] = arguments[_key];
-            }
-
-            var center, zoom;
+          function sync(...maps) {
+            let center, zoom;
 
             function update(ignore) {
-              maps.forEach(function(m) {
+              maps.forEach(m => {
                 if (m === ignore) {
                   return;
                 }
@@ -197,10 +126,10 @@
               });
             }
 
-            maps.forEach(function(m) {
-              m.addListener("bounds_changed", function() {
-                var changedCenter = m.getCenter();
-                var changedZoom = m.getZoom();
+            maps.forEach(m => {
+              m.addListener("bounds_changed", () => {
+                const changedCenter = m.getCenter();
+                const changedZoom = m.getZoom();
 
                 if (changedCenter !== center || changedZoom !== zoom) {
                   center = changedCenter;
@@ -214,16 +143,10 @@
           sync(exports.mapLeft, exports.mapRight);
 
           function handleContainerResize() {
-            var width = document.getElementById("container").offsetWidth;
+            const width = document.getElementById("container").offsetWidth;
             console.log(width);
-            document.getElementById("map-left").style.width = "".concat(
-              width,
-              "px"
-            );
-            document.getElementById("map-right").style.width = "".concat(
-              width,
-              "px"
-            );
+            document.getElementById("map-left").style.width = `${width}px`;
+            document.getElementById("map-right").style.width = `${width}px`;
           } // trigger to set map container size since using absolute
 
           handleContainerResize(); // add event listener

--- a/dist/samples/streetview-custom-tiles/app.js
+++ b/dist/samples/streetview-custom-tiles/app.js
@@ -25,7 +25,7 @@
         tileSize: new google.maps.Size(1024, 512),
         worldSize: new google.maps.Size(2048, 1024),
         centerHeading: 105,
-        getTileUrl: function getTileUrl(pano, zoom, tileX, tileY) {
+        getTileUrl: function(pano, zoom, tileX, tileY) {
           return (
             "https://developers.google.com/maps/documentation/javascript/examples/full/images/" +
             "panoReception1024-" +

--- a/dist/samples/streetview-custom-tiles/inline.html
+++ b/dist/samples/streetview-custom-tiles/inline.html
@@ -47,7 +47,7 @@
               tileSize: new google.maps.Size(1024, 512),
               worldSize: new google.maps.Size(2048, 1024),
               centerHeading: 105,
-              getTileUrl: function getTileUrl(pano, zoom, tileX, tileY) {
+              getTileUrl: function(pano, zoom, tileX, tileY) {
                 return (
                   "https://developers.google.com/maps/documentation/javascript/examples/full/images/" +
                   "panoReception1024-" +

--- a/rollup.config.iframe.js
+++ b/rollup.config.iframe.js
@@ -29,7 +29,7 @@ module.exports = {
           "@babel/env",
           {
             targets: {
-              browsers: "> 3%"
+              browsers: "ie>=11, > 1%"
             },
             corejs: "3.6",
             useBuiltIns: "usage"

--- a/rules/sample.bzl
+++ b/rules/sample.bzl
@@ -16,8 +16,23 @@ def sample():
     )
 
     rollup_bundle(
+        name = "iframe",
+        srcs = [":_app_without_region_tags.js"],
+        entry_point = "_app_without_region_tags.js",
+        config_file = "//:rollup.config.iframe.js",
+        format = "iife",
+        sourcemap = "false",
+        visibility = ["//visibility:public"],
+        deps = [
+            "@npm//@babel/core",
+            "@npm//@babel/preset-env",
+            "@npm//@rollup/plugin-babel",
+        ],
+    )
+
+    rollup_bundle(
         name = "_app",
-        srcs = [":_app_without_region_tags.js", "//:.babelrc"],
+        srcs = [":_app_without_region_tags.js"],
         entry_point = "_app_without_region_tags.js",
         config_file = "//:rollup.config.js",
         format = "iife",
@@ -122,11 +137,25 @@ def sample():
         visibility = ["//visibility:public"],
     )
 
+    # for local development
+    nunjucks(
+        name = "_index",
+        template = ":src/index.njk",
+        json = ":package.json",
+        data = [
+            ":src/index.njk",
+            ":package.json",
+            "//shared:templates",
+        ],
+        outs = ["_index.html"],
+        mode = "dev",
+    )
+
     native.genrule(
         name = "index_html",
-        srcs = [":_sample.html", ":app.js", ":style.css"],
+        srcs = [":_index.html", ":iframe.js", ":style.css"],
         outs = ["index.html"],
-        cmd = "$(location //rules:inline) $(location :_sample.html) $@; " +
+        cmd = "$(location //rules:inline) $(location :_index.html) $@; " +
               "$(location //rules:strip_region_tags_bin) $@; " +
               "sed -i'.bak' \"s/key=YOUR_API_KEY/key=$${GOOGLE_MAPS_JS_SAMPLES_KEY}/g\" $@; " +
               "$(location //rules:prettier) --write $@; ",
@@ -150,7 +179,7 @@ def sample():
     # the iframe output does not have any html, head, body tags. this is a consequence of Google's documentation site
     native.genrule(
         name = "iframe_html",
-        srcs = [":_iframe.html", ":app.js", ":style.css"],
+        srcs = [":_iframe.html", ":iframe.js", ":style.css"],
         outs = ["iframe.html"],
         cmd = "$(location //rules:inline) $(location :_iframe.html) $@; " +
               "$(location //rules:strip_region_tags_bin) $@; " +
@@ -171,11 +200,11 @@ def sample():
     native.filegroup(
         name = "html",
         srcs = [
-            ":index.html", # for development and googlemaps.github.io
-            ":jsfiddle.html", # for linkout to jsfiddle
-            ":sample.html", # for developers.google.com *html* tab
-            ":inline.html", # for developers.google.com *all* tab
-            ":iframe.html", # for developers.google.com iframe
+            ":index.html",  # for development and googlemaps.github.io
+            ":jsfiddle.html",  # for linkout to jsfiddle
+            ":sample.html",  # for developers.google.com *html* tab
+            ":inline.html",  # for developers.google.com *all* tab
+            ":iframe.html",  # for developers.google.com iframe
         ],
         visibility = ["//visibility:public"],
     )

--- a/shared/layout.njk
+++ b/shared/layout.njk
@@ -16,6 +16,9 @@
     <!-- [END maps_{{tag}}_htmll_head_api] -->
     {% if mode == "jsfiddle" %}
       <!-- jsFiddle will insert css and js -->
+    {% elif mode == "iframe" or mode == "dev" %}
+      <link rel="stylesheet" type="text/css" href="./style.css" data-inline>
+      <script src="./iframe.js" data-inline></script>
     {% else %}
       <link rel="stylesheet" type="text/css" href="./style.css" data-inline>
       <script src="./app.js" data-inline></script>


### PR DESCRIPTION
This relaxes the transpilation for all develoment outputs, specifically the js that will be shown in the documentation and the jsfiddle. The iframe and index.html will still be using the js transpiled to support ie and less popular browsers.