### PR TITLE
fix: replace yellow star with blue pushpin.

### DIFF
--- a/dist/samples/marker-symbol-custom/iframe.html
+++ b/dist/samples/marker-symbol-custom/iframe.html
@@ -37,7 +37,7 @@
       fillOpacity: 0.6,
       strokeColor: "blue",
       strokeWeight: 1,
-      rotation: 22,
+      rotation: 340,
       scale: 2,
       anchor: new google.maps.Point(15, 30),
     };

--- a/dist/samples/marker-symbol-custom/iframe.html
+++ b/dist/samples/marker-symbol-custom/iframe.html
@@ -22,28 +22,28 @@
   "use strict";
 
   // This example uses SVG path notation to add a vector-based symbol
-  // as the icon for a marker. The resulting icon is a star-shaped symbol
-  // with a pale yellow fill and a thick yellow border.
+  // as the icon for a marker. The resulting icon is a pushpin-shaped
+  // symbol with a blue fill and border.
   function initMap() {
+    var center = new google.maps.LatLng(-33.712451, 150.311823);
     var map = new google.maps.Map(document.getElementById("map"), {
-      zoom: 4,
-      center: {
-        lat: -25.363882,
-        lng: 131.044922,
-      },
+      zoom: 9,
+      center: center,
     });
-    var goldStar = {
+    var svgMarker = {
       path:
-        "M 125,5 155,90 245,90 175,145 200,230 125,180 50,230 75,145 5,90 95,90 z",
-      fillColor: "yellow",
-      fillOpacity: 0.8,
-      scale: 1,
-      strokeColor: "gold",
-      strokeWeight: 14,
+        "M20.5 15h-9c-1.104 0-2 0.896-2 2s0.896 2 2 2h9c1.104 0 2-0.896 2-2s-0.896-2-2-2zM13.583 8l-1.083 6h7l-1.084-6h-4.833zM16 29l1.5-9h-3l1.5 9zM13 7h6c0.828 0 1.5-0.672 1.5-1.5s-0.672-1.5-1.5-1.5h-6c-0.829 0-1.5 0.672-1.5 1.5s0.671 1.5 1.5 1.5z",
+      fillColor: "blue",
+      fillOpacity: 0.6,
+      strokeColor: "blue",
+      strokeWeight: 1,
+      rotation: 22,
+      scale: 2,
+      anchor: new google.maps.Point(15, 30),
     };
     new google.maps.Marker({
       position: map.getCenter(),
-      icon: goldStar,
+      icon: svgMarker,
       map: map,
     });
   }

--- a/dist/samples/marker-symbol-custom/index.html
+++ b/dist/samples/marker-symbol-custom/index.html
@@ -41,7 +41,7 @@
           fillOpacity: 0.6,
           strokeColor: "blue",
           strokeWeight: 1,
-          rotation: 22,
+          rotation: 340,
           scale: 2,
           anchor: new google.maps.Point(15, 30),
         };

--- a/dist/samples/marker-symbol-custom/index.html
+++ b/dist/samples/marker-symbol-custom/index.html
@@ -26,28 +26,28 @@
       "use strict";
 
       // This example uses SVG path notation to add a vector-based symbol
-      // as the icon for a marker. The resulting icon is a star-shaped symbol
-      // with a pale yellow fill and a thick yellow border.
+      // as the icon for a marker. The resulting icon is a pushpin-shaped
+      // symbol with a blue fill and border.
       function initMap() {
+        var center = new google.maps.LatLng(-33.712451, 150.311823);
         var map = new google.maps.Map(document.getElementById("map"), {
-          zoom: 4,
-          center: {
-            lat: -25.363882,
-            lng: 131.044922,
-          },
+          zoom: 9,
+          center: center,
         });
-        var goldStar = {
+        var svgMarker = {
           path:
-            "M 125,5 155,90 245,90 175,145 200,230 125,180 50,230 75,145 5,90 95,90 z",
-          fillColor: "yellow",
-          fillOpacity: 0.8,
-          scale: 1,
-          strokeColor: "gold",
-          strokeWeight: 14,
+            "M20.5 15h-9c-1.104 0-2 0.896-2 2s0.896 2 2 2h9c1.104 0 2-0.896 2-2s-0.896-2-2-2zM13.583 8l-1.083 6h7l-1.084-6h-4.833zM16 29l1.5-9h-3l1.5 9zM13 7h6c0.828 0 1.5-0.672 1.5-1.5s-0.672-1.5-1.5-1.5h-6c-0.829 0-1.5 0.672-1.5 1.5s0.671 1.5 1.5 1.5z",
+          fillColor: "blue",
+          fillOpacity: 0.6,
+          strokeColor: "blue",
+          strokeWeight: 1,
+          rotation: 22,
+          scale: 2,
+          anchor: new google.maps.Point(15, 30),
         };
         new google.maps.Marker({
           position: map.getCenter(),
-          icon: goldStar,
+          icon: svgMarker,
           map: map,
         });
       }

--- a/dist/samples/marker-symbol-custom/index.js
+++ b/dist/samples/marker-symbol-custom/index.js
@@ -1,24 +1,27 @@
 // [START maps_marker_symbol_custom]
 // This example uses SVG path notation to add a vector-based symbol
-// as the icon for a marker. The resulting icon is a star-shaped symbol
-// with a pale yellow fill and a thick yellow border.
+// as the icon for a marker. The resulting icon is a pushpin-shaped
+// symbol with a blue fill and border.
 function initMap() {
+  const center = new google.maps.LatLng(-33.712451, 150.311823);
   const map = new google.maps.Map(document.getElementById("map"), {
-    zoom: 4,
-    center: { lat: -25.363882, lng: 131.044922 },
+    zoom: 9,
+    center: center,
   });
-  const goldStar = {
+  const svgMarker = {
     path:
-      "M 125,5 155,90 245,90 175,145 200,230 125,180 50,230 75,145 5,90 95,90 z",
-    fillColor: "yellow",
-    fillOpacity: 0.8,
-    scale: 1,
-    strokeColor: "gold",
-    strokeWeight: 14,
+      "M20.5 15h-9c-1.104 0-2 0.896-2 2s0.896 2 2 2h9c1.104 0 2-0.896 2-2s-0.896-2-2-2zM13.583 8l-1.083 6h7l-1.084-6h-4.833zM16 29l1.5-9h-3l1.5 9zM13 7h6c0.828 0 1.5-0.672 1.5-1.5s-0.672-1.5-1.5-1.5h-6c-0.829 0-1.5 0.672-1.5 1.5s0.671 1.5 1.5 1.5z",
+    fillColor: "blue",
+    fillOpacity: 0.6,
+    strokeColor: "blue",
+    strokeWeight: 1,
+    rotation: 22,
+    scale: 2,
+    anchor: new google.maps.Point(15, 30),
   };
   new google.maps.Marker({
     position: map.getCenter(),
-    icon: goldStar,
+    icon: svgMarker,
     map: map,
   });
 }

--- a/dist/samples/marker-symbol-custom/index.js
+++ b/dist/samples/marker-symbol-custom/index.js
@@ -15,7 +15,7 @@ function initMap() {
     fillOpacity: 0.6,
     strokeColor: "blue",
     strokeWeight: 1,
-    rotation: 22,
+    rotation: 340,
     scale: 2,
     anchor: new google.maps.Point(15, 30),
   };

--- a/dist/samples/marker-symbol-custom/inline.html
+++ b/dist/samples/marker-symbol-custom/inline.html
@@ -24,25 +24,28 @@
     </style>
     <script>
       // This example uses SVG path notation to add a vector-based symbol
-      // as the icon for a marker. The resulting icon is a star-shaped symbol
-      // with a pale yellow fill and a thick yellow border.
+      // as the icon for a marker. The resulting icon is a pushpin-shaped
+      // symbol with a blue fill and border.
       function initMap() {
+        const center = new google.maps.LatLng(-33.712451, 150.311823);
         const map = new google.maps.Map(document.getElementById("map"), {
-          zoom: 4,
-          center: { lat: -25.363882, lng: 131.044922 },
+          zoom: 9,
+          center: center,
         });
-        const goldStar = {
+        const svgMarker = {
           path:
-            "M 125,5 155,90 245,90 175,145 200,230 125,180 50,230 75,145 5,90 95,90 z",
-          fillColor: "yellow",
-          fillOpacity: 0.8,
-          scale: 1,
-          strokeColor: "gold",
-          strokeWeight: 14,
+            "M20.5 15h-9c-1.104 0-2 0.896-2 2s0.896 2 2 2h9c1.104 0 2-0.896 2-2s-0.896-2-2-2zM13.583 8l-1.083 6h7l-1.084-6h-4.833zM16 29l1.5-9h-3l1.5 9zM13 7h6c0.828 0 1.5-0.672 1.5-1.5s-0.672-1.5-1.5-1.5h-6c-0.829 0-1.5 0.672-1.5 1.5s0.671 1.5 1.5 1.5z",
+          fillColor: "blue",
+          fillOpacity: 0.6,
+          strokeColor: "blue",
+          strokeWeight: 1,
+          rotation: 22,
+          scale: 2,
+          anchor: new google.maps.Point(15, 30),
         };
         new google.maps.Marker({
           position: map.getCenter(),
-          icon: goldStar,
+          icon: svgMarker,
           map: map,
         });
       }

--- a/dist/samples/marker-symbol-custom/inline.html
+++ b/dist/samples/marker-symbol-custom/inline.html
@@ -39,7 +39,7 @@
           fillOpacity: 0.6,
           strokeColor: "blue",
           strokeWeight: 1,
-          rotation: 22,
+          rotation: 340,
           scale: 2,
           anchor: new google.maps.Point(15, 30),
         };

--- a/dist/samples/marker-symbol-custom/jsfiddle.js
+++ b/dist/samples/marker-symbol-custom/jsfiddle.js
@@ -1,23 +1,26 @@
 // This example uses SVG path notation to add a vector-based symbol
-// as the icon for a marker. The resulting icon is a star-shaped symbol
-// with a pale yellow fill and a thick yellow border.
+// as the icon for a marker. The resulting icon is a pushpin-shaped
+// symbol with a blue fill and border.
 function initMap() {
+  const center = new google.maps.LatLng(-33.712451, 150.311823);
   const map = new google.maps.Map(document.getElementById("map"), {
-    zoom: 4,
-    center: { lat: -25.363882, lng: 131.044922 },
+    zoom: 9,
+    center: center,
   });
-  const goldStar = {
+  const svgMarker = {
     path:
-      "M 125,5 155,90 245,90 175,145 200,230 125,180 50,230 75,145 5,90 95,90 z",
-    fillColor: "yellow",
-    fillOpacity: 0.8,
-    scale: 1,
-    strokeColor: "gold",
-    strokeWeight: 14,
+      "M20.5 15h-9c-1.104 0-2 0.896-2 2s0.896 2 2 2h9c1.104 0 2-0.896 2-2s-0.896-2-2-2zM13.583 8l-1.083 6h7l-1.084-6h-4.833zM16 29l1.5-9h-3l1.5 9zM13 7h6c0.828 0 1.5-0.672 1.5-1.5s-0.672-1.5-1.5-1.5h-6c-0.829 0-1.5 0.672-1.5 1.5s0.671 1.5 1.5 1.5z",
+    fillColor: "blue",
+    fillOpacity: 0.6,
+    strokeColor: "blue",
+    strokeWeight: 1,
+    rotation: 22,
+    scale: 2,
+    anchor: new google.maps.Point(15, 30),
   };
   new google.maps.Marker({
     position: map.getCenter(),
-    icon: goldStar,
+    icon: svgMarker,
     map: map,
   });
 }

--- a/dist/samples/marker-symbol-custom/jsfiddle.js
+++ b/dist/samples/marker-symbol-custom/jsfiddle.js
@@ -14,7 +14,7 @@ function initMap() {
     fillOpacity: 0.6,
     strokeColor: "blue",
     strokeWeight: 1,
-    rotation: 22,
+    rotation: 340,
     scale: 2,
     anchor: new google.maps.Point(15, 30),
   };

--- a/samples/marker-symbol-custom/src/index.ts
+++ b/samples/marker-symbol-custom/src/index.ts
@@ -16,31 +16,34 @@
 
 // [START maps_marker_symbol_custom]
 // This example uses SVG path notation to add a vector-based symbol
-// as the icon for a marker. The resulting icon is a star-shaped symbol
-// with a pale yellow fill and a thick yellow border.
+// as the icon for a marker. The resulting icon is a pushpin-shaped
+// symbol with a blue fill and border.
 
 function initMap(): void {
+  const center = new google.maps.LatLng(-33.712451, 150.311823);
   const map = new google.maps.Map(
     document.getElementById("map") as HTMLElement,
     {
-      zoom: 4,
-      center: { lat: -25.363882, lng: 131.044922 },
+      zoom: 9,
+      center: center,
     }
   );
 
-  const goldStar = {
+  const svgMarker = {
     path:
-      "M 125,5 155,90 245,90 175,145 200,230 125,180 50,230 75,145 5,90 95,90 z",
-    fillColor: "yellow",
-    fillOpacity: 0.8,
-    scale: 1,
-    strokeColor: "gold",
-    strokeWeight: 14,
+      "M20.5 15h-9c-1.104 0-2 0.896-2 2s0.896 2 2 2h9c1.104 0 2-0.896 2-2s-0.896-2-2-2zM13.583 8l-1.083 6h7l-1.084-6h-4.833zM16 29l1.5-9h-3l1.5 9zM13 7h6c0.828 0 1.5-0.672 1.5-1.5s-0.672-1.5-1.5-1.5h-6c-0.829 0-1.5 0.672-1.5 1.5s0.671 1.5 1.5 1.5z",
+    fillColor: "blue",
+    fillOpacity: 0.6,
+    strokeColor: "blue",
+    strokeWeight: 1,
+    rotation: 340,
+    scale: 2,
+    anchor: new google.maps.Point(15, 30),
   };
 
   new google.maps.Marker({
     position: map.getCenter(),
-    icon: goldStar,
+    icon: svgMarker,
     map: map,
   });
 }


### PR DESCRIPTION
This update changes the big yellow star to a more sensibly-sized blue pushpin icon. It also adds the anchor property, which ensures that the marker will stay in position at different zoom levels.

Fixes  #541 🦕

https://developers.google.com/maps/documentation/javascript/examples/marker-symbol-custom
