### PR TITLE
Fix broken syntax on simple marker examples

### DIFF
--- a/dist/samples/marker-simple/iframe.html
+++ b/dist/samples/marker-simple/iframe.html
@@ -22,13 +22,13 @@
       lat: -25.363,
       lng: 131.044,
     };
-    var map = new google.maps.Map(document.getElementById("map"), {
+    var myMap = new google.maps.Map(document.getElementById("map"), {
       zoom: 4,
       center: myLatLng,
     });
     new google.maps.Marker({
       position: myLatLng,
-      map: map,
+      map: myMap,
       title: "Hello World!",
     });
   }

--- a/dist/samples/marker-simple/index.html
+++ b/dist/samples/marker-simple/index.html
@@ -26,13 +26,13 @@
           lat: -25.363,
           lng: 131.044,
         };
-        var map = new google.maps.Map(document.getElementById("map"), {
+        var myMap = new google.maps.Map(document.getElementById("map"), {
           zoom: 4,
           center: myLatLng,
         });
         new google.maps.Marker({
           position: myLatLng,
-          map: map,
+          map: myMap,
           title: "Hello World!",
         });
       }

--- a/dist/samples/marker-simple/index.js
+++ b/dist/samples/marker-simple/index.js
@@ -1,13 +1,13 @@
 // [START maps_marker_simple]
 function initMap() {
   const myLatLng = { lat: -25.363, lng: 131.044 };
-  const map = new google.maps.Map(document.getElementById("map"), {
+  const myMap = new google.maps.Map(document.getElementById("map"), {
     zoom: 4,
     center: myLatLng,
   });
   new google.maps.Marker({
     position: myLatLng,
-    map: map,
+    map: myMap,
     title: "Hello World!",
   });
 }

--- a/dist/samples/marker-simple/index.js
+++ b/dist/samples/marker-simple/index.js
@@ -7,7 +7,7 @@ function initMap() {
   });
   new google.maps.Marker({
     position: myLatLng,
-    map,
+    map: map,
     title: "Hello World!",
   });
 }

--- a/dist/samples/marker-simple/inline.html
+++ b/dist/samples/marker-simple/inline.html
@@ -27,7 +27,7 @@
         });
         new google.maps.Marker({
           position: myLatLng,
-          map,
+          map: map,
           title: "Hello World!",
         });
       }

--- a/dist/samples/marker-simple/inline.html
+++ b/dist/samples/marker-simple/inline.html
@@ -21,13 +21,13 @@
     <script>
       function initMap() {
         const myLatLng = { lat: -25.363, lng: 131.044 };
-        const map = new google.maps.Map(document.getElementById("map"), {
+        const myMap = new google.maps.Map(document.getElementById("map"), {
           zoom: 4,
           center: myLatLng,
         });
         new google.maps.Marker({
           position: myLatLng,
-          map: map,
+          map: myMap,
           title: "Hello World!",
         });
       }

--- a/dist/samples/marker-simple/jsfiddle.js
+++ b/dist/samples/marker-simple/jsfiddle.js
@@ -6,7 +6,7 @@ function initMap() {
   });
   new google.maps.Marker({
     position: myLatLng,
-    map,
+    map: map,
     title: "Hello World!",
   });
 }

--- a/dist/samples/marker-simple/jsfiddle.js
+++ b/dist/samples/marker-simple/jsfiddle.js
@@ -1,12 +1,12 @@
 function initMap() {
   const myLatLng = { lat: -25.363, lng: 131.044 };
-  const map = new google.maps.Map(document.getElementById("map"), {
+  const myMap = new google.maps.Map(document.getElementById("map"), {
     zoom: 4,
     center: myLatLng,
   });
   new google.maps.Marker({
     position: myLatLng,
-    map: map,
+    map: myMap,
     title: "Hello World!",
   });
 }

--- a/samples/marker-simple/src/index.ts
+++ b/samples/marker-simple/src/index.ts
@@ -18,7 +18,7 @@
 function initMap(): void {
   const myLatLng = { lat: -25.363, lng: 131.044 };
 
-  const map = new google.maps.Map(
+  const myMap = new google.maps.Map(
     document.getElementById("map") as HTMLElement,
     {
       zoom: 4,
@@ -28,7 +28,7 @@ function initMap(): void {
 
   new google.maps.Marker({
     position: myLatLng,
-    map: map,
+    map: myMap,
     title: "Hello World!",
   });
 }

--- a/samples/marker-simple/src/index.ts
+++ b/samples/marker-simple/src/index.ts
@@ -28,7 +28,7 @@ function initMap(): void {
 
   new google.maps.Marker({
     position: myLatLng,
-    map,
+    map: map,
     title: "Hello World!",
   });
 }


### PR DESCRIPTION
This pull request resolves syntax errors shown on https://developers.google.com/maps/documentation/javascript/examples/marker-simple#maps_marker_simple-javascript

This code in particular is broken syntax and will cause problems minifying and uglifying JavaScript

```js
function initMap() {
  const myLatLng = { lat: -25.363, lng: 131.044 };
  const map = new google.maps.Map(document.getElementById("map"), {
    zoom: 4,
    center: myLatLng,
  });
  new google.maps.Marker({
    position: myLatLng,
    map,
    title: "Hello World!",
  });
}
```

The primary issue is this

```js
  new google.maps.Marker({
    position: myLatLng,
    map,
    title: "Hello World!",
  });
}
```

Where the second argument being passed is the map object itself, instead of following the proper syntax of using a key value pair. This pull request changes this to.

```js
function initMap() {
  const myLatLng = { lat: -25.363, lng: 131.044 };
  const myMap = new google.maps.Map(document.getElementById("map"), {
    zoom: 4,
    center: myLatLng,
  });
  new google.maps.Marker({
    position: myLatLng,
    map: myMap,
    title: "Hello World!",
  });
}
```