### PR TITLE
fix: add margin to top of custom control

### DIFF
--- a/dist/samples/control-custom/iframe.html
+++ b/dist/samples/control-custom/iframe.html
@@ -37,6 +37,7 @@
     controlUI.style.borderRadius = "3px";
     controlUI.style.boxShadow = "0 2px 6px rgba(0,0,0,.3)";
     controlUI.style.cursor = "pointer";
+    controlUI.style.marginTop = "8px";
     controlUI.style.marginBottom = "22px";
     controlUI.style.textAlign = "center";
     controlUI.title = "Click to recenter the map";

--- a/dist/samples/control-custom/index.html
+++ b/dist/samples/control-custom/index.html
@@ -41,6 +41,7 @@
         controlUI.style.borderRadius = "3px";
         controlUI.style.boxShadow = "0 2px 6px rgba(0,0,0,.3)";
         controlUI.style.cursor = "pointer";
+        controlUI.style.marginTop = "8px";
         controlUI.style.marginBottom = "22px";
         controlUI.style.textAlign = "center";
         controlUI.title = "Click to recenter the map";

--- a/dist/samples/control-custom/index.js
+++ b/dist/samples/control-custom/index.js
@@ -16,6 +16,7 @@ function CenterControl(controlDiv, map) {
   controlUI.style.borderRadius = "3px";
   controlUI.style.boxShadow = "0 2px 6px rgba(0,0,0,.3)";
   controlUI.style.cursor = "pointer";
+  controlUI.style.marginTop = "8px";
   controlUI.style.marginBottom = "22px";
   controlUI.style.textAlign = "center";
   controlUI.title = "Click to recenter the map";

--- a/dist/samples/control-custom/inline.html
+++ b/dist/samples/control-custom/inline.html
@@ -36,6 +36,7 @@
         controlUI.style.borderRadius = "3px";
         controlUI.style.boxShadow = "0 2px 6px rgba(0,0,0,.3)";
         controlUI.style.cursor = "pointer";
+        controlUI.style.marginTop = "8px";
         controlUI.style.marginBottom = "22px";
         controlUI.style.textAlign = "center";
         controlUI.title = "Click to recenter the map";

--- a/dist/samples/control-custom/jsfiddle.js
+++ b/dist/samples/control-custom/jsfiddle.js
@@ -15,6 +15,7 @@ function CenterControl(controlDiv, map) {
   controlUI.style.borderRadius = "3px";
   controlUI.style.boxShadow = "0 2px 6px rgba(0,0,0,.3)";
   controlUI.style.cursor = "pointer";
+  controlUI.style.marginTop = "8px";
   controlUI.style.marginBottom = "22px";
   controlUI.style.textAlign = "center";
   controlUI.title = "Click to recenter the map";

--- a/samples/control-custom/src/index.ts
+++ b/samples/control-custom/src/index.ts
@@ -33,6 +33,7 @@ function CenterControl(controlDiv: Element, map: google.maps.Map) {
   controlUI.style.borderRadius = "3px";
   controlUI.style.boxShadow = "0 2px 6px rgba(0,0,0,.3)";
   controlUI.style.cursor = "pointer";
+  controlUI.style.marginTop = "8px";
   controlUI.style.marginBottom = "22px";
   controlUI.style.textAlign = "center";
   controlUI.title = "Click to recenter the map";


### PR DESCRIPTION
This PR fixes a minor display issue with the control-custom sample (the button touches the top of the map). To fix this, I have added another style to the CSS.

Fixes #631