### PR TITLE
Adjust margins around autocomplete addressform

### DIFF
--- a/dist/samples/places-autocomplete-addressform/iframe.html
+++ b/dist/samples/places-autocomplete-addressform/iframe.html
@@ -319,6 +319,9 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
       <input id="country" name="country" required />
     </label>
     <button type="button" class="my-button">Save address</button>
+
+    <!-- Reset button provided for development testing convenience.
+  Not recommended for user-facing forms due to risk of mis-click when aiming for Submit button. -->
     <input type="reset" value="Clear form" />
   </form>
 

--- a/dist/samples/places-autocomplete-addressform/iframe.html
+++ b/dist/samples/places-autocomplete-addressform/iframe.html
@@ -29,8 +29,7 @@
     display: flex;
     flex-wrap: wrap;
     max-width: 400px;
-    margin: 20px auto;
-    padding: 4rem 0;
+    padding: 20px;
   }
 
   input {
@@ -49,7 +48,15 @@
   }
 
   .title {
+    width: 100%;
+    margin-block-end: 0;
     font-weight: 500;
+  }
+
+  .note {
+    width: 100%;
+    margin-block-start: 0;
+    font-size: 12px;
   }
 
   .form-label {
@@ -268,9 +275,9 @@
 https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
     -->
 
-  <form action="" method="get" autocomplete="off">
-    <span class="title">Sample address form for North America</span><br />
-    <span><em>* = required field</em></span>
+  <form id="address-form" action="" method="get" autocomplete="off">
+    <p class="title">Sample address form for North America</p>
+    <p class="note"><em>* = required field</em></p>
     <label class="full-field">
       <!-- Avoid the word "address" in id, name, or label text to avoid browser autofill from conflicting with Place Autocomplete. Star or comment bug https://crbug.com/587466 to request Chromium to honor autocomplete="off" attribute. -->
       <span class="form-label">Deliver to*</span>

--- a/dist/samples/places-autocomplete-addressform/iframe.html
+++ b/dist/samples/places-autocomplete-addressform/iframe.html
@@ -96,6 +96,19 @@
     position: relative;
     top: 1px;
   }
+
+  .clear-form-text {
+    padding: 6px 0;
+    align-self: flex-end;
+  }
+
+  .clear-form-text:link {
+    padding: 6px 0;
+    align-self: center;
+    color: #686868;
+    font-size: 14px;
+    text-decoration: none;
+  }
 </style>
 <script>
   "use strict";
@@ -309,6 +322,11 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
       <input id="country" name="country" required />
     </label>
     <button type="button" class="my-button">Save address</button>
+    <a
+      class="clear-form-text"
+      href="javascript:document.getElementById('address-form').reset();"
+      >Clear form</a
+    >
   </form>
 
   <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/iframe.html
+++ b/dist/samples/places-autocomplete-addressform/iframe.html
@@ -28,6 +28,7 @@
   form {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     max-width: 400px;
     padding: 20px;
   }
@@ -45,6 +46,15 @@
 
   input:focus {
     border-bottom: 4px solid black;
+  }
+
+  input[type="reset"] {
+    width: auto;
+    height: auto;
+    border-bottom: 0;
+    background-color: transparent;
+    color: #686868;
+    font-size: 14px;
   }
 
   .title {
@@ -95,19 +105,6 @@
   .my-button:active {
     position: relative;
     top: 1px;
-  }
-
-  .clear-form-text {
-    padding: 6px 0;
-    align-self: flex-end;
-  }
-
-  .clear-form-text:link {
-    padding: 6px 0;
-    align-self: center;
-    color: #686868;
-    font-size: 14px;
-    text-decoration: none;
   }
 </style>
 <script>
@@ -322,11 +319,7 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
       <input id="country" name="country" required />
     </label>
     <button type="button" class="my-button">Save address</button>
-    <a
-      class="clear-form-text"
-      href="javascript:document.getElementById('address-form').reset();"
-      >Clear form</a
-    >
+    <input type="reset" value="Clear form" />
   </form>
 
   <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/index.html
+++ b/dist/samples/places-autocomplete-addressform/index.html
@@ -326,6 +326,9 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+
+      <!-- Reset button provided for development testing convenience.
+  Not recommended for user-facing forms due to risk of mis-click when aiming for Submit button. -->
       <input type="reset" value="Clear form" />
     </form>
 

--- a/dist/samples/places-autocomplete-addressform/index.html
+++ b/dist/samples/places-autocomplete-addressform/index.html
@@ -100,6 +100,19 @@
         position: relative;
         top: 1px;
       }
+
+      .clear-form-text {
+        padding: 6px 0;
+        align-self: flex-end;
+      }
+
+      .clear-form-text:link {
+        padding: 6px 0;
+        align-self: center;
+        color: #686868;
+        font-size: 14px;
+        text-decoration: none;
+      }
     </style>
     <script>
       "use strict";
@@ -316,6 +329,11 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+      <a
+        class="clear-form-text"
+        href="javascript:document.getElementById('address-form').reset();"
+        >Clear form</a
+      >
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/index.html
+++ b/dist/samples/places-autocomplete-addressform/index.html
@@ -33,8 +33,7 @@
         display: flex;
         flex-wrap: wrap;
         max-width: 400px;
-        margin: 20px auto;
-        padding: 4rem 0;
+        padding: 20px;
       }
 
       input {
@@ -53,7 +52,15 @@
       }
 
       .title {
+        width: 100%;
+        margin-block-end: 0;
         font-weight: 500;
+      }
+
+      .note {
+        width: 100%;
+        margin-block-start: 0;
+        font-size: 12px;
       }
 
       .form-label {
@@ -275,9 +282,9 @@
 https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
     -->
 
-    <form action="" method="get" autocomplete="off">
-      <span class="title">Sample address form for North America</span><br />
-      <span><em>* = required field</em></span>
+    <form id="address-form" action="" method="get" autocomplete="off">
+      <p class="title">Sample address form for North America</p>
+      <p class="note"><em>* = required field</em></p>
       <label class="full-field">
         <!-- Avoid the word "address" in id, name, or label text to avoid browser autofill from conflicting with Place Autocomplete. Star or comment bug https://crbug.com/587466 to request Chromium to honor autocomplete="off" attribute. -->
         <span class="form-label">Deliver to*</span>

--- a/dist/samples/places-autocomplete-addressform/index.html
+++ b/dist/samples/places-autocomplete-addressform/index.html
@@ -32,6 +32,7 @@
       form {
         display: flex;
         flex-wrap: wrap;
+        align-items: center;
         max-width: 400px;
         padding: 20px;
       }
@@ -49,6 +50,15 @@
 
       input:focus {
         border-bottom: 4px solid black;
+      }
+
+      input[type="reset"] {
+        width: auto;
+        height: auto;
+        border-bottom: 0;
+        background-color: transparent;
+        color: #686868;
+        font-size: 14px;
       }
 
       .title {
@@ -99,19 +109,6 @@
       .my-button:active {
         position: relative;
         top: 1px;
-      }
-
-      .clear-form-text {
-        padding: 6px 0;
-        align-self: flex-end;
-      }
-
-      .clear-form-text:link {
-        padding: 6px 0;
-        align-self: center;
-        color: #686868;
-        font-size: 14px;
-        text-decoration: none;
       }
     </style>
     <script>
@@ -329,11 +326,7 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
-      <a
-        class="clear-form-text"
-        href="javascript:document.getElementById('address-form').reset();"
-        >Clear form</a
-      >
+      <input type="reset" value="Clear form" />
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/inline.html
+++ b/dist/samples/places-autocomplete-addressform/inline.html
@@ -32,6 +32,7 @@
       form {
         display: flex;
         flex-wrap: wrap;
+        align-items: center;
         max-width: 400px;
         padding: 20px;
       }
@@ -49,6 +50,15 @@
 
       input:focus {
         border-bottom: 4px solid black;
+      }
+
+      input[type="reset"] {
+        width: auto;
+        height: auto;
+        border-bottom: 0;
+        background-color: transparent;
+        color: #686868;
+        font-size: 14px;
       }
 
       .title {
@@ -99,19 +109,6 @@
       .my-button:active {
         position: relative;
         top: 1px;
-      }
-
-      .clear-form-text {
-        padding: 6px 0;
-        align-self: flex-end;
-      }
-
-      .clear-form-text:link {
-        padding: 6px 0;
-        align-self: center;
-        color: #686868;
-        font-size: 14px;
-        text-decoration: none;
       }
     </style>
     <script>
@@ -239,11 +236,7 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
-      <a
-        class="clear-form-text"
-        href="javascript:document.getElementById('address-form').reset();"
-        >Clear form</a
-      >
+      <input type="reset" value="Clear form" />
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/inline.html
+++ b/dist/samples/places-autocomplete-addressform/inline.html
@@ -236,6 +236,9 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+
+      <!-- Reset button provided for development testing convenience.
+  Not recommended for user-facing forms due to risk of mis-click when aiming for Submit button. -->
       <input type="reset" value="Clear form" />
     </form>
 

--- a/dist/samples/places-autocomplete-addressform/inline.html
+++ b/dist/samples/places-autocomplete-addressform/inline.html
@@ -33,8 +33,7 @@
         display: flex;
         flex-wrap: wrap;
         max-width: 400px;
-        margin: 20px auto;
-        padding: 4rem 0;
+        padding: 20px;
       }
 
       input {
@@ -53,7 +52,15 @@
       }
 
       .title {
+        width: 100%;
+        margin-block-end: 0;
         font-weight: 500;
+      }
+
+      .note {
+        width: 100%;
+        margin-block-start: 0;
+        font-size: 12px;
       }
 
       .form-label {
@@ -185,9 +192,9 @@
 https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
     -->
 
-    <form action="" method="get" autocomplete="off">
-      <span class="title">Sample address form for North America</span><br />
-      <span><em>* = required field</em></span>
+    <form id="address-form" action="" method="get" autocomplete="off">
+      <p class="title">Sample address form for North America</p>
+      <p class="note"><em>* = required field</em></p>
       <label class="full-field">
         <!-- Avoid the word "address" in id, name, or label text to avoid browser autofill from conflicting with Place Autocomplete. Star or comment bug https://crbug.com/587466 to request Chromium to honor autocomplete="off" attribute. -->
         <span class="form-label">Deliver to*</span>

--- a/dist/samples/places-autocomplete-addressform/inline.html
+++ b/dist/samples/places-autocomplete-addressform/inline.html
@@ -100,6 +100,19 @@
         position: relative;
         top: 1px;
       }
+
+      .clear-form-text {
+        padding: 6px 0;
+        align-self: flex-end;
+      }
+
+      .clear-form-text:link {
+        padding: 6px 0;
+        align-self: center;
+        color: #686868;
+        font-size: 14px;
+        text-decoration: none;
+      }
     </style>
     <script>
       // This sample uses the Places Autocomplete widget to:
@@ -226,6 +239,11 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+      <a
+        class="clear-form-text"
+        href="javascript:document.getElementById('address-form').reset();"
+        >Clear form</a
+      >
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/jsfiddle.html
+++ b/dist/samples/places-autocomplete-addressform/jsfiddle.html
@@ -49,6 +49,11 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+      <a
+        class="clear-form-text"
+        href="javascript:document.getElementById('address-form').reset();"
+        >Clear form</a
+      >
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/jsfiddle.html
+++ b/dist/samples/places-autocomplete-addressform/jsfiddle.html
@@ -15,9 +15,9 @@
 https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
     -->
 
-    <form action="" method="get" autocomplete="off">
-      <span class="title">Sample address form for North America</span><br />
-      <span><em>* = required field</em></span>
+    <form id="address-form" action="" method="get" autocomplete="off">
+      <p class="title">Sample address form for North America</p>
+      <p class="note"><em>* = required field</em></p>
       <label class="full-field">
         <!-- Avoid the word "address" in id, name, or label text to avoid browser autofill from conflicting with Place Autocomplete. Star or comment bug https://crbug.com/587466 to request Chromium to honor autocomplete="off" attribute. -->
         <span class="form-label">Deliver to*</span>

--- a/dist/samples/places-autocomplete-addressform/jsfiddle.html
+++ b/dist/samples/places-autocomplete-addressform/jsfiddle.html
@@ -49,11 +49,7 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
-      <a
-        class="clear-form-text"
-        href="javascript:document.getElementById('address-form').reset();"
-        >Clear form</a
-      >
+      <input type="reset" value="Clear form" />
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/jsfiddle.html
+++ b/dist/samples/places-autocomplete-addressform/jsfiddle.html
@@ -49,6 +49,9 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+
+      <!-- Reset button provided for development testing convenience.
+  Not recommended for user-facing forms due to risk of mis-click when aiming for Submit button. -->
       <input type="reset" value="Clear form" />
     </form>
 

--- a/dist/samples/places-autocomplete-addressform/sample.html
+++ b/dist/samples/places-autocomplete-addressform/sample.html
@@ -51,11 +51,7 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
-      <a
-        class="clear-form-text"
-        href="javascript:document.getElementById('address-form').reset();"
-        >Clear form</a
-      >
+      <input type="reset" value="Clear form" />
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/sample.html
+++ b/dist/samples/places-autocomplete-addressform/sample.html
@@ -51,6 +51,9 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+
+      <!-- Reset button provided for development testing convenience.
+  Not recommended for user-facing forms due to risk of mis-click when aiming for Submit button. -->
       <input type="reset" value="Clear form" />
     </form>
 

--- a/dist/samples/places-autocomplete-addressform/sample.html
+++ b/dist/samples/places-autocomplete-addressform/sample.html
@@ -17,9 +17,9 @@
 https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
     -->
 
-    <form action="" method="get" autocomplete="off">
-      <span class="title">Sample address form for North America</span><br />
-      <span><em>* = required field</em></span>
+    <form id="address-form" action="" method="get" autocomplete="off">
+      <p class="title">Sample address form for North America</p>
+      <p class="note"><em>* = required field</em></p>
       <label class="full-field">
         <!-- Avoid the word "address" in id, name, or label text to avoid browser autofill from conflicting with Place Autocomplete. Star or comment bug https://crbug.com/587466 to request Chromium to honor autocomplete="off" attribute. -->
         <span class="form-label">Deliver to*</span>

--- a/dist/samples/places-autocomplete-addressform/sample.html
+++ b/dist/samples/places-autocomplete-addressform/sample.html
@@ -51,6 +51,11 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
         <input id="country" name="country" required />
       </label>
       <button type="button" class="my-button">Save address</button>
+      <a
+        class="clear-form-text"
+        href="javascript:document.getElementById('address-form').reset();"
+        >Clear form</a
+      >
     </form>
 
     <!-- Async script executes immediately and must be after any DOM elements used in callback. -->

--- a/dist/samples/places-autocomplete-addressform/style.css
+++ b/dist/samples/places-autocomplete-addressform/style.css
@@ -23,8 +23,7 @@ form {
   display: flex;
   flex-wrap: wrap;
   max-width: 400px;
-  margin: 20px auto;
-  padding: 4rem 0;
+  padding: 20px;
 }
 
 input {
@@ -43,7 +42,15 @@ input:focus {
 }
 
 .title {
+  width: 100%;
+  margin-block-end: 0;
   font-weight: 500;
+}
+
+.note {
+  width: 100%;
+  margin-block-start: 0;
+  font-size: 12px;
 }
 
 .form-label {

--- a/dist/samples/places-autocomplete-addressform/style.css
+++ b/dist/samples/places-autocomplete-addressform/style.css
@@ -91,4 +91,17 @@ input:focus {
   top: 1px;
 }
 
+.clear-form-text {
+  padding: 6px 0;
+  align-self: flex-end;
+}
+
+.clear-form-text:link {
+  padding: 6px 0;
+  align-self: center;
+  color: #686868;
+  font-size: 14px;
+  text-decoration: none;
+}
+
 /* [END maps_places_autocomplete_addressform] */

--- a/dist/samples/places-autocomplete-addressform/style.css
+++ b/dist/samples/places-autocomplete-addressform/style.css
@@ -22,6 +22,7 @@ body {
 form {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   max-width: 400px;
   padding: 20px;
 }
@@ -39,6 +40,15 @@ input {
 
 input:focus {
   border-bottom: 4px solid black;
+}
+
+input[type="reset"] {
+  width: auto;
+  height: auto;
+  border-bottom: 0;
+  background-color: transparent;
+  color: #686868;
+  font-size: 14px;
 }
 
 .title {
@@ -89,19 +99,6 @@ input:focus {
 .my-button:active {
   position: relative;
   top: 1px;
-}
-
-.clear-form-text {
-  padding: 6px 0;
-  align-self: flex-end;
-}
-
-.clear-form-text:link {
-  padding: 6px 0;
-  align-self: center;
-  color: #686868;
-  font-size: 14px;
-  text-decoration: none;
 }
 
 /* [END maps_places_autocomplete_addressform] */

--- a/samples/places-autocomplete-addressform/src/index.njk
+++ b/samples/places-autocomplete-addressform/src/index.njk
@@ -51,7 +51,7 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
     <input id="country" name="country" required>
   </label>
   <button type="button" class="my-button">Save address</button>
-   <a class="clear-form-text" href="javascript:document.getElementById('address-form').reset();">Clear form</a>
+  <input type="reset" value="Clear form">
 </form>
 
 {% endblock %}

--- a/samples/places-autocomplete-addressform/src/index.njk
+++ b/samples/places-autocomplete-addressform/src/index.njk
@@ -51,6 +51,7 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
     <input id="country" name="country" required>
   </label>
   <button type="button" class="my-button">Save address</button>
+   <a class="clear-form-text" href="javascript:document.getElementById('address-form').reset();">Clear form</a>
 </form>
 
 {% endblock %}

--- a/samples/places-autocomplete-addressform/src/index.njk
+++ b/samples/places-autocomplete-addressform/src/index.njk
@@ -22,9 +22,9 @@
 https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
     -->
 
-<form action="" method="get" autocomplete="off">
-  <span class="title">Sample address form for North America</span><br>
-  <span><em>* = required field</em></span>
+<form id="address-form" action="" method="get" autocomplete="off">
+  <p class="title">Sample address form for North America</p>
+  <p class="note"><em>* = required field</em></p>
   <label class="full-field">
     <!-- Avoid the word "address" in id, name, or label text to avoid browser autofill from conflicting with Place Autocomplete. Star or comment bug https://crbug.com/587466 to request Chromium to honor autocomplete="off" attribute. -->
     <span class="form-label">Deliver to*</span>

--- a/samples/places-autocomplete-addressform/src/index.njk
+++ b/samples/places-autocomplete-addressform/src/index.njk
@@ -51,6 +51,9 @@ https://developers.google.com/maps/documentation/javascript/examples/places-auto
     <input id="country" name="country" required>
   </label>
   <button type="button" class="my-button">Save address</button>
+
+  <!-- Reset button provided for development testing convenience.
+  Not recommended for user-facing forms due to risk of mis-click when aiming for Submit button. -->
   <input type="reset" value="Clear form">
 </form>
 

--- a/samples/places-autocomplete-addressform/src/style.scss
+++ b/samples/places-autocomplete-addressform/src/style.scss
@@ -29,8 +29,7 @@ form {
   display: flex;
   flex-wrap: wrap;
   max-width: 400px;
-  margin: 20px auto;
-  padding: 4rem 0;
+  padding: 20px;
 }
 
 input {
@@ -49,7 +48,15 @@ input:focus {
 }
 
 .title {
+  width: 100%;
+  margin-block-end: 0;
   font-weight: 500;
+}
+
+.note {
+  width: 100%;
+  margin-block-start: 0;
+  font-size: 12px;
 }
 
 .form-label {

--- a/samples/places-autocomplete-addressform/src/style.scss
+++ b/samples/places-autocomplete-addressform/src/style.scss
@@ -94,4 +94,17 @@ input:focus {
 	position:relative;
 	top:1px;
 }
+ 
+.clear-form-text {
+  padding: 6px 0;
+  align-self: flex-end;
+}
+ 
+.clear-form-text:link {
+  padding: 6px 0;
+  align-self: center;
+  color: rgb(104, 104, 104);
+  font-size: 14px; 
+  text-decoration: none;
+}
 /* [END maps_places_autocomplete_addressform] */

--- a/samples/places-autocomplete-addressform/src/style.scss
+++ b/samples/places-autocomplete-addressform/src/style.scss
@@ -28,6 +28,7 @@ body {
 form {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   max-width: 400px;
   padding: 20px;
 }
@@ -45,6 +46,15 @@ input {
 
 input:focus {
   border-bottom: 4px solid black;
+}
+
+input[type='reset'] {
+  width: auto;
+  height: auto;
+  border-bottom: 0;
+  background-color: transparent;
+  color: rgb(104, 104, 104);
+  font-size: 14px;
 }
 
 .title {
@@ -93,18 +103,5 @@ input:focus {
 .my-button:active {
 	position:relative;
 	top:1px;
-}
- 
-.clear-form-text {
-  padding: 6px 0;
-  align-self: flex-end;
-}
- 
-.clear-form-text:link {
-  padding: 6px 0;
-  align-self: center;
-  color: rgb(104, 104, 104);
-  font-size: 14px; 
-  text-decoration: none;
 }
 /* [END maps_places_autocomplete_addressform] */


### PR DESCRIPTION
Address form margins caused inconsistent display in [sample documentation](https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform), so removing the horizontally centered margins.

Also found during testing that it would be useful to have a "Clear form" button to try different addresses.
