### PR TITLE
fix: use beta version of webpack dev server for globals

### DIFF
--- a/samples/marker-accessibility/src/index.ts
+++ b/samples/marker-accessibility/src/index.ts
@@ -49,7 +49,7 @@ function initMap(): void {
       map,
       title: `${i + 1}. ${title}`,
       label: `${i + 1}`,
-      optimized: false
+      optimized: false,
     });
 
     // Add a click listener for each marker, and set up the info window.

--- a/shared/package/package.json
+++ b/shared/package/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.1.5",
     "webpack": "^5.24.3",
     "webpack-cli": "^4.5.0",
-    "webpack-dev-server": "^3.11.2",
+    "webpack-dev-server": "^4.0.0-beta.2",
     "webpack-merge": "^5.7.3"
   }
 }

--- a/shared/package/webpack.dev.js
+++ b/shared/package/webpack.dev.js
@@ -22,12 +22,9 @@ module.exports = merge(common, {
   watch: true,
   devtool: "inline-source-map",
   devServer: {
-    contentBase: path.resolve(__dirname, "public"),
     liveReload: true,
     host: "0.0.0.0",
     port: 8080,
     historyApiFallback: true,
-    writeToDisk: true,
-    disableHostCheck: true,
   },
 });


### PR DESCRIPTION
fixes #645 by using a new version of dev-server bypassing https://github.com/webpack/webpack-dev-server/issues/2484