### PR TITLE
Add 45-degree tilt view to store locator sample

### DIFF
--- a/dist/samples/store-locator/iframe.html
+++ b/dist/samples/store-locator/iframe.html
@@ -92,6 +92,8 @@
   "use strict";
 
   var map;
+  var originalMapTypeId;
+  var detailMapTypeId;
   var autocomplete;
   var autocompleteInput;
   var distanceMatrixService;
@@ -101,11 +103,14 @@
 
   function initMap() {
     distanceMatrixService = new google.maps.DistanceMatrixService();
+    originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+    detailMapTypeId = google.maps.MapTypeId.HYBRID;
     map = new google.maps.Map(document.getElementById("map"), {
       center: {
         lat: 39.79,
         lng: -104.98,
       },
+      mapTypeId: originalMapTypeId,
       zoom: 10,
     });
     new mdc.textField.MDCTextField(document.querySelector(".mdc-text-field"));
@@ -143,7 +148,7 @@
             },
           });
           marker.addListener("click", function () {
-            update(
+            seeDetail(
               new google.maps.LatLng({
                 lat: lat,
                 lng: lng,
@@ -217,7 +222,7 @@
       card
         .querySelector(".mdc-card__primary-action")
         .addEventListener("click", function () {
-          map.panTo(location);
+          seeDetail(new google.maps.LatLng(location));
         });
       cardsDiv.appendChild(card);
     });
@@ -268,7 +273,9 @@
 
     autocompleteInput.disabled = true;
     isUpdateInProgress = true;
-    map.setCenter(location); // reset values
+    map.setCenter(location);
+    map.setZoom(10);
+    map.setMapTypeId(originalMapTypeId); // reset values
 
     stores.forEach(function (store) {
       delete store.travelDistance;
@@ -308,6 +315,21 @@
         autocompleteInput.disabled = false;
         isUpdateInProgress = false;
       });
+  }
+
+  function seeDetail(location) {
+    update(location);
+    map.setZoom(19);
+    map.setMapTypeId(detailMapTypeId);
+    map.setTilt(45);
+    map.addListener("zoom_changed", function () {
+      var newZoom = map.getZoom();
+
+      if (newZoom < 19) {
+        map.setTilt(0);
+        map.setMapTypeId(originalMapTypeId);
+      }
+    });
   }
 </script>
 

--- a/dist/samples/store-locator/iframe.html
+++ b/dist/samples/store-locator/iframe.html
@@ -55,6 +55,7 @@
 
   #sidebar {
     flex-basis: 5rem;
+    flex-direction: column;
   }
 
   #search,

--- a/dist/samples/store-locator/index.html
+++ b/dist/samples/store-locator/index.html
@@ -60,6 +60,7 @@
 
       #sidebar {
         flex-basis: 5rem;
+        flex-direction: column;
       }
 
       #search,

--- a/dist/samples/store-locator/index.html
+++ b/dist/samples/store-locator/index.html
@@ -97,6 +97,8 @@
       "use strict";
 
       var map;
+      var originalMapTypeId;
+      var detailMapTypeId;
       var autocomplete;
       var autocompleteInput;
       var distanceMatrixService;
@@ -106,11 +108,14 @@
 
       function initMap() {
         distanceMatrixService = new google.maps.DistanceMatrixService();
+        originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+        detailMapTypeId = google.maps.MapTypeId.HYBRID;
         map = new google.maps.Map(document.getElementById("map"), {
           center: {
             lat: 39.79,
             lng: -104.98,
           },
+          mapTypeId: originalMapTypeId,
           zoom: 10,
         });
         new mdc.textField.MDCTextField(
@@ -153,7 +158,7 @@
                 },
               });
               marker.addListener("click", function () {
-                update(
+                seeDetail(
                   new google.maps.LatLng({
                     lat: lat,
                     lng: lng,
@@ -231,7 +236,7 @@
           card
             .querySelector(".mdc-card__primary-action")
             .addEventListener("click", function () {
-              map.panTo(location);
+              seeDetail(new google.maps.LatLng(location));
             });
           cardsDiv.appendChild(card);
         });
@@ -282,7 +287,9 @@
 
         autocompleteInput.disabled = true;
         isUpdateInProgress = true;
-        map.setCenter(location); // reset values
+        map.setCenter(location);
+        map.setZoom(10);
+        map.setMapTypeId(originalMapTypeId); // reset values
 
         stores.forEach(function (store) {
           delete store.travelDistance;
@@ -322,6 +329,21 @@
             autocompleteInput.disabled = false;
             isUpdateInProgress = false;
           });
+      }
+
+      function seeDetail(location) {
+        update(location);
+        map.setZoom(19);
+        map.setMapTypeId(detailMapTypeId);
+        map.setTilt(45);
+        map.addListener("zoom_changed", function () {
+          var newZoom = map.getZoom();
+
+          if (newZoom < 19) {
+            map.setTilt(0);
+            map.setMapTypeId(originalMapTypeId);
+          }
+        });
       }
     </script>
   </head>

--- a/dist/samples/store-locator/index.js
+++ b/dist/samples/store-locator/index.js
@@ -1,5 +1,7 @@
 // [START maps_store_locator]
 let map;
+let originalMapTypeId;
+let detailMapTypeId;
 let autocomplete;
 let autocompleteInput;
 let distanceMatrixService;
@@ -10,8 +12,11 @@ const stores = [];
 // Initialize and add the map
 function initMap() {
   distanceMatrixService = new google.maps.DistanceMatrixService();
+  originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+  detailMapTypeId = google.maps.MapTypeId.HYBRID;
   map = new google.maps.Map(document.getElementById("map"), {
     center: { lat: 39.79, lng: -104.98 },
+    mapTypeId: originalMapTypeId,
     zoom: 10,
   });
 
@@ -34,7 +39,7 @@ function initMap() {
           stores.push({ name, location: { lat, lng }, address: "" });
           const marker = new google.maps.Marker({ position: { lat, lng } });
           marker.addListener("click", () => {
-            update(new google.maps.LatLng({ lat, lng }));
+            seeDetail(new google.maps.LatLng({ lat, lng }));
           });
           markers.push(marker);
         }
@@ -103,7 +108,7 @@ function renderCards(stores) {
         card
           .querySelector(".mdc-card__primary-action")
           .addEventListener("click", () => {
-            map.panTo(location);
+            seeDetail(new google.maps.LatLng(location));
           });
         cardsDiv.appendChild(card);
       }
@@ -152,6 +157,8 @@ function update(location) {
   autocompleteInput.disabled = true;
   isUpdateInProgress = true;
   map.setCenter(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
   // reset values
   stores.forEach((store) => {
     delete store.travelDistance;
@@ -189,5 +196,20 @@ function update(location) {
       autocompleteInput.disabled = false;
       isUpdateInProgress = false;
     });
+}
+
+function seeDetail(location) {
+  update(location);
+  map.setZoom(19);
+  map.setMapTypeId(detailMapTypeId);
+  map.setTilt(45);
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom();
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
 }
 // [END maps_store_locator]

--- a/dist/samples/store-locator/index.js
+++ b/dist/samples/store-locator/index.js
@@ -14,6 +14,7 @@ function initMap() {
     center: { lat: 39.79, lng: -104.98 },
     zoom: 10,
   });
+
   new mdc.textField.MDCTextField(document.querySelector(".mdc-text-field"));
   autocompleteInput = document.getElementById("search-input");
   autocomplete = new google.maps.places.Autocomplete(autocompleteInput, {});
@@ -38,6 +39,7 @@ function initMap() {
           markers.push(marker);
         }
       );
+
       new MarkerClusterer(map, markers, {
         imagePath:
           "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",

--- a/dist/samples/store-locator/inline.html
+++ b/dist/samples/store-locator/inline.html
@@ -60,6 +60,7 @@
 
       #sidebar {
         flex-basis: 5rem;
+        flex-direction: column;
       }
 
       #search,
@@ -108,6 +109,7 @@
           center: { lat: 39.79, lng: -104.98 },
           zoom: 10,
         });
+
         new mdc.textField.MDCTextField(
           document.querySelector(".mdc-text-field")
         );
@@ -142,6 +144,7 @@
                 markers.push(marker);
               }
             );
+
             new MarkerClusterer(map, markers, {
               imagePath:
                 "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",

--- a/dist/samples/store-locator/inline.html
+++ b/dist/samples/store-locator/inline.html
@@ -95,6 +95,8 @@
     </style>
     <script>
       let map;
+      let originalMapTypeId;
+      let detailMapTypeId;
       let autocomplete;
       let autocompleteInput;
       let distanceMatrixService;
@@ -105,8 +107,11 @@
       // Initialize and add the map
       function initMap() {
         distanceMatrixService = new google.maps.DistanceMatrixService();
+        originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+        detailMapTypeId = google.maps.MapTypeId.HYBRID;
         map = new google.maps.Map(document.getElementById("map"), {
           center: { lat: 39.79, lng: -104.98 },
+          mapTypeId: originalMapTypeId,
           zoom: 10,
         });
 
@@ -139,7 +144,7 @@
                   position: { lat, lng },
                 });
                 marker.addListener("click", () => {
-                  update(new google.maps.LatLng({ lat, lng }));
+                  seeDetail(new google.maps.LatLng({ lat, lng }));
                 });
                 markers.push(marker);
               }
@@ -214,7 +219,7 @@
               card
                 .querySelector(".mdc-card__primary-action")
                 .addEventListener("click", () => {
-                  map.panTo(location);
+                  seeDetail(new google.maps.LatLng(location));
                 });
               cardsDiv.appendChild(card);
             }
@@ -263,6 +268,8 @@
         autocompleteInput.disabled = true;
         isUpdateInProgress = true;
         map.setCenter(location);
+        map.setZoom(10);
+        map.setMapTypeId(originalMapTypeId);
         // reset values
         stores.forEach((store) => {
           delete store.travelDistance;
@@ -302,6 +309,21 @@
             autocompleteInput.disabled = false;
             isUpdateInProgress = false;
           });
+      }
+
+      function seeDetail(location) {
+        update(location);
+        map.setZoom(19);
+        map.setMapTypeId(detailMapTypeId);
+        map.setTilt(45);
+        map.addListener("zoom_changed", () => {
+          const newZoom = map.getZoom();
+
+          if (newZoom < 19) {
+            map.setTilt(0);
+            map.setMapTypeId(originalMapTypeId);
+          }
+        });
       }
     </script>
   </head>

--- a/dist/samples/store-locator/jsfiddle.js
+++ b/dist/samples/store-locator/jsfiddle.js
@@ -13,6 +13,7 @@ function initMap() {
     center: { lat: 39.79, lng: -104.98 },
     zoom: 10,
   });
+
   new mdc.textField.MDCTextField(document.querySelector(".mdc-text-field"));
   autocompleteInput = document.getElementById("search-input");
   autocomplete = new google.maps.places.Autocomplete(autocompleteInput, {});
@@ -37,6 +38,7 @@ function initMap() {
           markers.push(marker);
         }
       );
+
       new MarkerClusterer(map, markers, {
         imagePath:
           "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",

--- a/dist/samples/store-locator/jsfiddle.js
+++ b/dist/samples/store-locator/jsfiddle.js
@@ -1,4 +1,6 @@
 let map;
+let originalMapTypeId;
+let detailMapTypeId;
 let autocomplete;
 let autocompleteInput;
 let distanceMatrixService;
@@ -9,8 +11,11 @@ const stores = [];
 // Initialize and add the map
 function initMap() {
   distanceMatrixService = new google.maps.DistanceMatrixService();
+  originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+  detailMapTypeId = google.maps.MapTypeId.HYBRID;
   map = new google.maps.Map(document.getElementById("map"), {
     center: { lat: 39.79, lng: -104.98 },
+    mapTypeId: originalMapTypeId,
     zoom: 10,
   });
 
@@ -33,7 +38,7 @@ function initMap() {
           stores.push({ name, location: { lat, lng }, address: "" });
           const marker = new google.maps.Marker({ position: { lat, lng } });
           marker.addListener("click", () => {
-            update(new google.maps.LatLng({ lat, lng }));
+            seeDetail(new google.maps.LatLng({ lat, lng }));
           });
           markers.push(marker);
         }
@@ -102,7 +107,7 @@ function renderCards(stores) {
         card
           .querySelector(".mdc-card__primary-action")
           .addEventListener("click", () => {
-            map.panTo(location);
+            seeDetail(new google.maps.LatLng(location));
           });
         cardsDiv.appendChild(card);
       }
@@ -151,6 +156,8 @@ function update(location) {
   autocompleteInput.disabled = true;
   isUpdateInProgress = true;
   map.setCenter(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
   // reset values
   stores.forEach((store) => {
     delete store.travelDistance;
@@ -188,4 +195,19 @@ function update(location) {
       autocompleteInput.disabled = false;
       isUpdateInProgress = false;
     });
+}
+
+function seeDetail(location) {
+  update(location);
+  map.setZoom(19);
+  map.setMapTypeId(detailMapTypeId);
+  map.setTilt(45);
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom();
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
 }

--- a/dist/samples/store-locator/style.css
+++ b/dist/samples/store-locator/style.css
@@ -41,6 +41,7 @@ body {
 
 #sidebar {
   flex-basis: 5rem;
+  flex-direction: column;
 }
 
 #search,

--- a/samples/store-locator/src/index.ts
+++ b/samples/store-locator/src/index.ts
@@ -15,6 +15,8 @@
  */
 // [START maps_store_locator]
 let map: google.maps.Map;
+let originalMapTypeId: google.maps.MapTypeId;
+let detailMapTypeId: google.maps.MapTypeId;
 let autocomplete: google.maps.places.Autocomplete;
 let autocompleteInput: HTMLInputElement;
 let distanceMatrixService: google.maps.DistanceMatrixService;
@@ -37,9 +39,12 @@ const stores: Store[] = [];
 // Initialize and add the map
 function initMap(): void {
   distanceMatrixService = new google.maps.DistanceMatrixService();
+  originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+  detailMapTypeId = google.maps.MapTypeId.HYBRID;
 
   map = new google.maps.Map(document.getElementById("map") as HTMLElement, {
     center: { lat: 39.79, lng: -104.98 },
+    mapTypeId: originalMapTypeId,
     zoom: 10,
   });
 
@@ -74,7 +79,7 @@ function initMap(): void {
           stores.push({ name, location: { lat, lng }, address: "" });
           const marker = new google.maps.Marker({ position: { lat, lng } });
           marker.addListener("click", () => {
-            update(new google.maps.LatLng({ lat, lng }));
+            seeDetail(new google.maps.LatLng({ lat, lng }));
           });
           markers.push(marker);
         }
@@ -158,7 +163,7 @@ function renderCards(stores: Store[]): void {
         (card.querySelector(
           ".mdc-card__primary-action"
         ) as HTMLElement).addEventListener("click", () => {
-          map.panTo(location);
+          seeDetail(new google.maps.LatLng(location));
         });
 
         cardsDiv.appendChild(card);
@@ -218,6 +223,8 @@ function update(location?: google.maps.LatLng) {
   autocompleteInput.disabled = true;
   isUpdateInProgress = true;
   map.setCenter(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
 
   // reset values
   stores.forEach((store) => {
@@ -258,6 +265,22 @@ function update(location?: google.maps.LatLng) {
       autocompleteInput.disabled = false;
       isUpdateInProgress = false;
     });
+}
+
+function seeDetail(location: google.maps.LatLng) {
+  update(location);
+  map.setZoom(19);
+  map.setMapTypeId(detailMapTypeId);
+  map.setTilt(45);
+
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom()!;
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
 }
 
 // [END maps_store_locator]

--- a/samples/store-locator/src/style.scss
+++ b/samples/store-locator/src/style.scss
@@ -26,6 +26,7 @@
 
 #sidebar {
   flex-basis: 5rem; // override the default sidebar basis
+  flex-direction: column;
 }
 
 #search,


### PR DESCRIPTION
When user clicks on a marker or store name in the list view, zoom in on that location and switch the map view to a 45-degree tilt hybrid map. When the user zooms back out for any reason, revert to the original map type. If 45-degree imagery is not available at the chosen location, 0-degree tilt imagery is displayed.
