### PR TITLE
feat: add 45-degree map view to store locator when viewing location details

### DIFF
--- a/dist/samples/store-locator/iframe.html
+++ b/dist/samples/store-locator/iframe.html
@@ -106,23 +106,26 @@
         },
       },
       t = {};
-    let n, a, o, r;
+    let n, a, o, r, s, d;
     e.r(t), e.d(t, { initMap: () => i });
-    let s = !1;
-    const c = [];
+    let c = !1;
+    const l = [];
     function i() {
-      (r = new google.maps.DistanceMatrixService()),
+      (d = new google.maps.DistanceMatrixService()),
+        (a = google.maps.MapTypeId.ROADMAP),
+        (o = google.maps.MapTypeId.HYBRID),
         (n = new google.maps.Map(document.getElementById("map"), {
           center: { lat: 39.79, lng: -104.98 },
+          mapTypeId: a,
           zoom: 10,
         })),
         new mdc.textField.MDCTextField(
           document.querySelector(".mdc-text-field")
         ),
-        (o = document.getElementById("search-input")),
-        (a = new google.maps.places.Autocomplete(o, {})),
-        a.addListener("place_changed", l),
-        a.bindTo("bounds", n),
+        (s = document.getElementById("search-input")),
+        (r = new google.maps.places.Autocomplete(s, {})),
+        r.addListener("place_changed", m),
+        r.bindTo("bounds", n),
         fetch(
           "https://carto.nationalmap.gov/arcgis/rest/services/structures/MapServer/23/query?where=STATE%3D%27CO%27&returnGeometry=true&outSR=4326&f=pjson"
         )
@@ -132,12 +135,12 @@
               a = [];
             t.forEach(
               ({ attributes: { NAME: e }, geometry: { x: t, y: n } }) => {
-                c.push({ name: e, location: { lat: n, lng: t }, address: "" });
+                l.push({ name: e, location: { lat: n, lng: t }, address: "" });
                 const o = new google.maps.Marker({
                   position: { lat: n, lng: t },
                 });
                 o.addListener("click", () => {
-                  d(new google.maps.LatLng({ lat: n, lng: t }));
+                  p(new google.maps.LatLng({ lat: n, lng: t }));
                 }),
                   a.push(o);
               }
@@ -147,37 +150,39 @@
                   "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",
               }),
               (void 0).done(),
-              d(n.getCenter());
+              g(n.getCenter());
           }),
         document.getElementById("near-me").addEventListener("click", () => {
           navigator.geolocation &&
             navigator.geolocation.getCurrentPosition(
               ({ coords: { latitude: e, longitude: t } }) => {
-                d(new google.maps.LatLng({ lat: e, lng: t }));
+                g(new google.maps.LatLng({ lat: e, lng: t }));
               }
             );
         }),
         document.getElementById("refresh").addEventListener("click", () => {
-          d(n.getCenter());
+          g(n.getCenter());
         });
     }
-    function l() {
-      (o.disabled = !0), d(a.getPlace().geometry.location);
+    function m() {
+      (s.disabled = !0), g(r.getPlace().geometry.location);
     }
-    function d(e) {
+    function g(e) {
       e &&
-        (s
+        (c
           ? alert("Update in progress, please try again.")
-          : ((o.disabled = !0),
-            (s = !0),
+          : ((s.disabled = !0),
+            (c = !0),
             n.setCenter(e),
-            c.forEach((e) => {
+            n.setZoom(10),
+            n.setMapTypeId(a),
+            l.forEach((e) => {
               delete e.travelDistance,
                 delete e.travelDistanceText,
                 delete e.travelDuration,
                 delete e.travelDurationText;
             }),
-            c.sort(
+            l.sort(
               (t, n) =>
                 google.maps.geometry.spherical.computeDistanceBetween(
                   new google.maps.LatLng(t.location),
@@ -191,10 +196,10 @@
             (function (e) {
               const t = [e];
               return new Promise((e, n) => {
-                r.getDistanceMatrix(
+                d.getDistanceMatrix(
                   {
                     origins: t,
-                    destinations: c.slice(0, 25).map((e) => e.location),
+                    destinations: l.slice(0, 25).map((e) => e.location),
                     travelMode: google.maps.TravelMode.DRIVING,
                     unitSystem: google.maps.UnitSystem.IMPERIAL,
                   },
@@ -208,14 +213,14 @@
             })(e)
               .then((e) => {
                 for (let t = 0; t < e.rows[0].elements.length; t++)
-                  (c[t].address = e.destinationAddresses[t]),
-                    (c[t].travelDistance =
+                  (l[t].address = e.destinationAddresses[t]),
+                    (l[t].travelDistance =
                       e.rows[0].elements[t].distance.value),
-                    (c[t].travelDistanceText =
+                    (l[t].travelDistanceText =
                       e.rows[0].elements[t].distance.text),
-                    (c[t].travelDuration =
+                    (l[t].travelDuration =
                       e.rows[0].elements[t].duration.value),
-                    (c[t].travelDurationText =
+                    (l[t].travelDurationText =
                       e.rows[0].elements[t].duration.text);
               })
               .finally(() => {
@@ -227,38 +232,47 @@
                       .forEach(
                         ({
                           name: e,
-                          location: a,
-                          address: o,
-                          travelDistanceText: r,
-                          travelDurationText: s,
+                          location: n,
+                          address: a,
+                          travelDistanceText: o,
+                          travelDurationText: r,
                         }) => {
-                          const c = document.createElement("div");
-                          c.classList.add("mdc-card", "mdc-card--outlined"),
-                            (c.innerHTML = `\n<div class="mdc-card__primary-action">\n  <div id="card-header">\n    <h2 class="mdc-typography--headline6">${e}</h2>\n  </div>\n</div>\n<div id="card-body">\n  </div>\n<div class="mdc-card__actions">\n  <a class="mdc-button mdc-card__action mdc-card__action--button" \n    target="_blank" href="https://maps.google.com?q=${
-                              o || e
+                          const s = document.createElement("div");
+                          s.classList.add("mdc-card", "mdc-card--outlined"),
+                            (s.innerHTML = `\n<div class="mdc-card__primary-action">\n  <div id="card-header">\n    <h2 class="mdc-typography--headline6">${e}</h2>\n  </div>\n</div>\n<div id="card-body">\n  </div>\n<div class="mdc-card__actions">\n  <a class="mdc-button mdc-card__action mdc-card__action--button"\n    target="_blank" href="https://maps.google.com?q=${
+                              a || e
                             }">\n    <div class="mdc-button__ripple"></div>\n    <span class="mdc-button__label">Directions</span>\n  </a>\n  <button class="mdc-button mdc-card__action mdc-card__action--button">\n    <div class="mdc-button__ripple"></div>\n    <span class="mdc-button__label">More Information</span>\n  </button>\n</div>`);
-                          const i = c.querySelector("#card-body");
-                          o &&
-                            (i.innerHTML = `<h2 class="mdc-typography--body1">${o}</h2>`),
-                            r &&
-                              (i.innerHTML += `<h2 class="mdc-typography--body2">${r}, ${s}</h2>`),
-                            c
+                          const d = s.querySelector("#card-body");
+                          a &&
+                            (d.innerHTML = `<h2 class="mdc-typography--body1">${a}</h2>`),
+                            o &&
+                              (d.innerHTML += `<h2 class="mdc-typography--body2">${o}, ${r}</h2>`),
+                            s
                               .querySelector(".mdc-card__primary-action")
                               .addEventListener("click", () => {
-                                n.panTo(a);
+                                p(new google.maps.LatLng(n));
                               }),
-                            t.appendChild(c);
+                            t.appendChild(s);
                         }
                       ),
                     t.scrollTo(0, 0);
-                })(c),
-                  (o.disabled = !1),
-                  (s = !1);
+                })(l),
+                  (s.disabled = !1),
+                  (c = !1);
               })));
     }
-    var m = window;
-    for (var g in t) m[g] = t[g];
-    t.__esModule && Object.defineProperty(m, "__esModule", { value: !0 });
+    function p(e) {
+      g(e),
+        n.setZoom(19),
+        n.setMapTypeId(o),
+        n.setTilt(45),
+        n.addListener("zoom_changed", () => {
+          n.getZoom() < 19 && (n.setTilt(0), n.setMapTypeId(a));
+        });
+    }
+    var u = window;
+    for (var y in t) u[y] = t[y];
+    t.__esModule && Object.defineProperty(u, "__esModule", { value: !0 });
   })();
 </script>
 

--- a/dist/samples/store-locator/index.html
+++ b/dist/samples/store-locator/index.html
@@ -113,23 +113,26 @@
             },
           },
           t = {};
-        let n, a, o, r;
+        let n, a, o, r, s, d;
         e.r(t), e.d(t, { initMap: () => i });
-        let s = !1;
-        const c = [];
+        let c = !1;
+        const l = [];
         function i() {
-          (r = new google.maps.DistanceMatrixService()),
+          (d = new google.maps.DistanceMatrixService()),
+            (a = google.maps.MapTypeId.ROADMAP),
+            (o = google.maps.MapTypeId.HYBRID),
             (n = new google.maps.Map(document.getElementById("map"), {
               center: { lat: 39.79, lng: -104.98 },
+              mapTypeId: a,
               zoom: 10,
             })),
             new mdc.textField.MDCTextField(
               document.querySelector(".mdc-text-field")
             ),
-            (o = document.getElementById("search-input")),
-            (a = new google.maps.places.Autocomplete(o, {})),
-            a.addListener("place_changed", l),
-            a.bindTo("bounds", n),
+            (s = document.getElementById("search-input")),
+            (r = new google.maps.places.Autocomplete(s, {})),
+            r.addListener("place_changed", m),
+            r.bindTo("bounds", n),
             fetch(
               "https://carto.nationalmap.gov/arcgis/rest/services/structures/MapServer/23/query?where=STATE%3D%27CO%27&returnGeometry=true&outSR=4326&f=pjson"
             )
@@ -139,7 +142,7 @@
                   a = [];
                 t.forEach(
                   ({ attributes: { NAME: e }, geometry: { x: t, y: n } }) => {
-                    c.push({
+                    l.push({
                       name: e,
                       location: { lat: n, lng: t },
                       address: "",
@@ -148,7 +151,7 @@
                       position: { lat: n, lng: t },
                     });
                     o.addListener("click", () => {
-                      d(new google.maps.LatLng({ lat: n, lng: t }));
+                      p(new google.maps.LatLng({ lat: n, lng: t }));
                     }),
                       a.push(o);
                   }
@@ -158,37 +161,39 @@
                       "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",
                   }),
                   (void 0).done(),
-                  d(n.getCenter());
+                  g(n.getCenter());
               }),
             document.getElementById("near-me").addEventListener("click", () => {
               navigator.geolocation &&
                 navigator.geolocation.getCurrentPosition(
                   ({ coords: { latitude: e, longitude: t } }) => {
-                    d(new google.maps.LatLng({ lat: e, lng: t }));
+                    g(new google.maps.LatLng({ lat: e, lng: t }));
                   }
                 );
             }),
             document.getElementById("refresh").addEventListener("click", () => {
-              d(n.getCenter());
+              g(n.getCenter());
             });
         }
-        function l() {
-          (o.disabled = !0), d(a.getPlace().geometry.location);
+        function m() {
+          (s.disabled = !0), g(r.getPlace().geometry.location);
         }
-        function d(e) {
+        function g(e) {
           e &&
-            (s
+            (c
               ? alert("Update in progress, please try again.")
-              : ((o.disabled = !0),
-                (s = !0),
+              : ((s.disabled = !0),
+                (c = !0),
                 n.setCenter(e),
-                c.forEach((e) => {
+                n.setZoom(10),
+                n.setMapTypeId(a),
+                l.forEach((e) => {
                   delete e.travelDistance,
                     delete e.travelDistanceText,
                     delete e.travelDuration,
                     delete e.travelDurationText;
                 }),
-                c.sort(
+                l.sort(
                   (t, n) =>
                     google.maps.geometry.spherical.computeDistanceBetween(
                       new google.maps.LatLng(t.location),
@@ -202,10 +207,10 @@
                 (function (e) {
                   const t = [e];
                   return new Promise((e, n) => {
-                    r.getDistanceMatrix(
+                    d.getDistanceMatrix(
                       {
                         origins: t,
-                        destinations: c.slice(0, 25).map((e) => e.location),
+                        destinations: l.slice(0, 25).map((e) => e.location),
                         travelMode: google.maps.TravelMode.DRIVING,
                         unitSystem: google.maps.UnitSystem.IMPERIAL,
                       },
@@ -219,14 +224,14 @@
                 })(e)
                   .then((e) => {
                     for (let t = 0; t < e.rows[0].elements.length; t++)
-                      (c[t].address = e.destinationAddresses[t]),
-                        (c[t].travelDistance =
+                      (l[t].address = e.destinationAddresses[t]),
+                        (l[t].travelDistance =
                           e.rows[0].elements[t].distance.value),
-                        (c[t].travelDistanceText =
+                        (l[t].travelDistanceText =
                           e.rows[0].elements[t].distance.text),
-                        (c[t].travelDuration =
+                        (l[t].travelDuration =
                           e.rows[0].elements[t].duration.value),
-                        (c[t].travelDurationText =
+                        (l[t].travelDurationText =
                           e.rows[0].elements[t].duration.text);
                   })
                   .finally(() => {
@@ -238,38 +243,47 @@
                           .forEach(
                             ({
                               name: e,
-                              location: a,
-                              address: o,
-                              travelDistanceText: r,
-                              travelDurationText: s,
+                              location: n,
+                              address: a,
+                              travelDistanceText: o,
+                              travelDurationText: r,
                             }) => {
-                              const c = document.createElement("div");
-                              c.classList.add("mdc-card", "mdc-card--outlined"),
-                                (c.innerHTML = `\n<div class="mdc-card__primary-action">\n  <div id="card-header">\n    <h2 class="mdc-typography--headline6">${e}</h2>\n  </div>\n</div>\n<div id="card-body">\n  </div>\n<div class="mdc-card__actions">\n  <a class="mdc-button mdc-card__action mdc-card__action--button" \n    target="_blank" href="https://maps.google.com?q=${
-                                  o || e
+                              const s = document.createElement("div");
+                              s.classList.add("mdc-card", "mdc-card--outlined"),
+                                (s.innerHTML = `\n<div class="mdc-card__primary-action">\n  <div id="card-header">\n    <h2 class="mdc-typography--headline6">${e}</h2>\n  </div>\n</div>\n<div id="card-body">\n  </div>\n<div class="mdc-card__actions">\n  <a class="mdc-button mdc-card__action mdc-card__action--button"\n    target="_blank" href="https://maps.google.com?q=${
+                                  a || e
                                 }">\n    <div class="mdc-button__ripple"></div>\n    <span class="mdc-button__label">Directions</span>\n  </a>\n  <button class="mdc-button mdc-card__action mdc-card__action--button">\n    <div class="mdc-button__ripple"></div>\n    <span class="mdc-button__label">More Information</span>\n  </button>\n</div>`);
-                              const i = c.querySelector("#card-body");
-                              o &&
-                                (i.innerHTML = `<h2 class="mdc-typography--body1">${o}</h2>`),
-                                r &&
-                                  (i.innerHTML += `<h2 class="mdc-typography--body2">${r}, ${s}</h2>`),
-                                c
+                              const d = s.querySelector("#card-body");
+                              a &&
+                                (d.innerHTML = `<h2 class="mdc-typography--body1">${a}</h2>`),
+                                o &&
+                                  (d.innerHTML += `<h2 class="mdc-typography--body2">${o}, ${r}</h2>`),
+                                s
                                   .querySelector(".mdc-card__primary-action")
                                   .addEventListener("click", () => {
-                                    n.panTo(a);
+                                    p(new google.maps.LatLng(n));
                                   }),
-                                t.appendChild(c);
+                                t.appendChild(s);
                             }
                           ),
                         t.scrollTo(0, 0);
-                    })(c),
-                      (o.disabled = !1),
-                      (s = !1);
+                    })(l),
+                      (s.disabled = !1),
+                      (c = !1);
                   })));
         }
-        var m = window;
-        for (var g in t) m[g] = t[g];
-        t.__esModule && Object.defineProperty(m, "__esModule", { value: !0 });
+        function p(e) {
+          g(e),
+            n.setZoom(19),
+            n.setMapTypeId(o),
+            n.setTilt(45),
+            n.addListener("zoom_changed", () => {
+              n.getZoom() < 19 && (n.setTilt(0), n.setMapTypeId(a));
+            });
+        }
+        var u = window;
+        for (var y in t) u[y] = t[y];
+        t.__esModule && Object.defineProperty(u, "__esModule", { value: !0 });
       })();
     </script>
   </head>

--- a/dist/samples/store-locator/index.js
+++ b/dist/samples/store-locator/index.js
@@ -1,5 +1,7 @@
 // [START maps_store_locator]
 let map;
+let originalMapTypeId;
+let detailMapTypeId;
 let autocomplete;
 let autocompleteInput;
 let distanceMatrixService;
@@ -10,8 +12,11 @@ const stores = [];
 // Initialize and add the map
 function initMap() {
   distanceMatrixService = new google.maps.DistanceMatrixService();
+  originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+  detailMapTypeId = google.maps.MapTypeId.HYBRID;
   map = new google.maps.Map(document.getElementById("map"), {
     center: { lat: 39.79, lng: -104.98 },
+    mapTypeId: originalMapTypeId,
     zoom: 10,
   });
   new mdc.textField.MDCTextField(document.querySelector(".mdc-text-field"));
@@ -33,7 +38,7 @@ function initMap() {
           stores.push({ name, location: { lat, lng }, address: "" });
           const marker = new google.maps.Marker({ position: { lat, lng } });
           marker.addListener("click", () => {
-            update(new google.maps.LatLng({ lat, lng }));
+            seeDetail(new google.maps.LatLng({ lat, lng }));
           });
           markers.push(marker);
         }
@@ -77,7 +82,7 @@ function renderCards(stores) {
 <div id="card-body">
   </div>
 <div class="mdc-card__actions">
-  <a class="mdc-button mdc-card__action mdc-card__action--button" 
+  <a class="mdc-button mdc-card__action mdc-card__action--button"
     target="_blank" href="https://maps.google.com?q=${
       address ? address : name
     }">
@@ -101,7 +106,7 @@ function renderCards(stores) {
         card
           .querySelector(".mdc-card__primary-action")
           .addEventListener("click", () => {
-            map.panTo(location);
+            seeDetail(new google.maps.LatLng(location));
           });
         cardsDiv.appendChild(card);
       }
@@ -150,6 +155,8 @@ function update(location) {
   autocompleteInput.disabled = true;
   isUpdateInProgress = true;
   map.setCenter(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
   // reset values
   stores.forEach((store) => {
     delete store.travelDistance;
@@ -187,5 +194,20 @@ function update(location) {
       autocompleteInput.disabled = false;
       isUpdateInProgress = false;
     });
+}
+
+function seeDetail(location) {
+  update(location);
+  map.setZoom(19);
+  map.setMapTypeId(detailMapTypeId);
+  map.setTilt(45);
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom();
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
 }
 // [END maps_store_locator]

--- a/dist/samples/store-locator/inline.html
+++ b/dist/samples/store-locator/inline.html
@@ -94,6 +94,8 @@
     </style>
     <script>
       let map;
+      let originalMapTypeId;
+      let detailMapTypeId;
       let autocomplete;
       let autocompleteInput;
       let distanceMatrixService;
@@ -104,8 +106,11 @@
       // Initialize and add the map
       function initMap() {
         distanceMatrixService = new google.maps.DistanceMatrixService();
+        originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+        detailMapTypeId = google.maps.MapTypeId.HYBRID;
         map = new google.maps.Map(document.getElementById("map"), {
           center: { lat: 39.79, lng: -104.98 },
+          mapTypeId: originalMapTypeId,
           zoom: 10,
         });
         new mdc.textField.MDCTextField(
@@ -137,7 +142,7 @@
                   position: { lat, lng },
                 });
                 marker.addListener("click", () => {
-                  update(new google.maps.LatLng({ lat, lng }));
+                  seeDetail(new google.maps.LatLng({ lat, lng }));
                 });
                 markers.push(marker);
               }
@@ -187,7 +192,7 @@
 <div id="card-body">
   </div>
 <div class="mdc-card__actions">
-  <a class="mdc-button mdc-card__action mdc-card__action--button" 
+  <a class="mdc-button mdc-card__action mdc-card__action--button"
     target="_blank" href="https://maps.google.com?q=${
       address ? address : name
     }">
@@ -211,7 +216,7 @@
               card
                 .querySelector(".mdc-card__primary-action")
                 .addEventListener("click", () => {
-                  map.panTo(location);
+                  seeDetail(new google.maps.LatLng(location));
                 });
               cardsDiv.appendChild(card);
             }
@@ -260,6 +265,8 @@
         autocompleteInput.disabled = true;
         isUpdateInProgress = true;
         map.setCenter(location);
+        map.setZoom(10);
+        map.setMapTypeId(originalMapTypeId);
         // reset values
         stores.forEach((store) => {
           delete store.travelDistance;
@@ -299,6 +306,21 @@
             autocompleteInput.disabled = false;
             isUpdateInProgress = false;
           });
+      }
+
+      function seeDetail(location) {
+        update(location);
+        map.setZoom(19);
+        map.setMapTypeId(detailMapTypeId);
+        map.setTilt(45);
+        map.addListener("zoom_changed", () => {
+          const newZoom = map.getZoom();
+
+          if (newZoom < 19) {
+            map.setTilt(0);
+            map.setMapTypeId(originalMapTypeId);
+          }
+        });
       }
     </script>
   </head>

--- a/dist/samples/store-locator/jsfiddle.js
+++ b/dist/samples/store-locator/jsfiddle.js
@@ -1,4 +1,6 @@
 let map;
+let originalMapTypeId;
+let detailMapTypeId;
 let autocomplete;
 let autocompleteInput;
 let distanceMatrixService;
@@ -9,8 +11,11 @@ const stores = [];
 // Initialize and add the map
 function initMap() {
   distanceMatrixService = new google.maps.DistanceMatrixService();
+  originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+  detailMapTypeId = google.maps.MapTypeId.HYBRID;
   map = new google.maps.Map(document.getElementById("map"), {
     center: { lat: 39.79, lng: -104.98 },
+    mapTypeId: originalMapTypeId,
     zoom: 10,
   });
   new mdc.textField.MDCTextField(document.querySelector(".mdc-text-field"));
@@ -32,7 +37,7 @@ function initMap() {
           stores.push({ name, location: { lat, lng }, address: "" });
           const marker = new google.maps.Marker({ position: { lat, lng } });
           marker.addListener("click", () => {
-            update(new google.maps.LatLng({ lat, lng }));
+            seeDetail(new google.maps.LatLng({ lat, lng }));
           });
           markers.push(marker);
         }
@@ -76,7 +81,7 @@ function renderCards(stores) {
 <div id="card-body">
   </div>
 <div class="mdc-card__actions">
-  <a class="mdc-button mdc-card__action mdc-card__action--button" 
+  <a class="mdc-button mdc-card__action mdc-card__action--button"
     target="_blank" href="https://maps.google.com?q=${
       address ? address : name
     }">
@@ -100,7 +105,7 @@ function renderCards(stores) {
         card
           .querySelector(".mdc-card__primary-action")
           .addEventListener("click", () => {
-            map.panTo(location);
+            seeDetail(new google.maps.LatLng(location));
           });
         cardsDiv.appendChild(card);
       }
@@ -149,6 +154,8 @@ function update(location) {
   autocompleteInput.disabled = true;
   isUpdateInProgress = true;
   map.setCenter(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
   // reset values
   stores.forEach((store) => {
     delete store.travelDistance;
@@ -186,4 +193,19 @@ function update(location) {
       autocompleteInput.disabled = false;
       isUpdateInProgress = false;
     });
+}
+
+function seeDetail(location) {
+  update(location);
+  map.setZoom(19);
+  map.setMapTypeId(detailMapTypeId);
+  map.setTilt(45);
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom();
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
 }


### PR DESCRIPTION
When user clicks on a marker or store name in the list view, zoom in on that location and switch the map view to a 45-degree tilt hybrid map. When the user zooms back out for any reason, revert to the original map type. If 45-degree imagery is not available at the chosen location, 0-degree tilt imagery is displayed.
