### PR TITLE
fix: remove default controls from Directions sample

### DIFF
--- a/dist/samples/directions-panel/iframe.html
+++ b/dist/samples/directions-panel/iframe.html
@@ -105,12 +105,13 @@
         o = new google.maps.Map(document.getElementById("map"), {
           zoom: 7,
           center: { lat: 41.85, lng: -87.65 },
+          disableDefaultUI: !0,
         });
       e.setMap(o), e.setPanel(document.getElementById("right-panel"));
       const n = document.getElementById("floating-panel");
       (n.style.display = "block"),
         o.controls[google.maps.ControlPosition.TOP_CENTER].push(n);
-      const r = function () {
+      const l = function () {
         !(function (e, t) {
           const o = document.getElementById("start").value,
             n = document.getElementById("end").value;
@@ -128,12 +129,12 @@
           );
         })(t, e);
       };
-      document.getElementById("start").addEventListener("change", r),
-        document.getElementById("end").addEventListener("change", r);
+      document.getElementById("start").addEventListener("change", l),
+        document.getElementById("end").addEventListener("change", l);
     }
     e.r(t), e.d(t, { initMap: () => o });
     var n = window;
-    for (var r in t) n[r] = t[r];
+    for (var l in t) n[l] = t[l];
     t.__esModule && Object.defineProperty(n, "__esModule", { value: !0 });
   })();
 </script>

--- a/dist/samples/directions-panel/index.html
+++ b/dist/samples/directions-panel/index.html
@@ -111,12 +111,13 @@
             o = new google.maps.Map(document.getElementById("map"), {
               zoom: 7,
               center: { lat: 41.85, lng: -87.65 },
+              disableDefaultUI: !0,
             });
           e.setMap(o), e.setPanel(document.getElementById("right-panel"));
           const n = document.getElementById("floating-panel");
           (n.style.display = "block"),
             o.controls[google.maps.ControlPosition.TOP_CENTER].push(n);
-          const r = function () {
+          const l = function () {
             !(function (e, t) {
               const o = document.getElementById("start").value,
                 n = document.getElementById("end").value;
@@ -134,12 +135,12 @@
               );
             })(t, e);
           };
-          document.getElementById("start").addEventListener("change", r),
-            document.getElementById("end").addEventListener("change", r);
+          document.getElementById("start").addEventListener("change", l),
+            document.getElementById("end").addEventListener("change", l);
         }
         e.r(t), e.d(t, { initMap: () => o });
         var n = window;
-        for (var r in t) n[r] = t[r];
+        for (var l in t) n[l] = t[l];
         t.__esModule && Object.defineProperty(n, "__esModule", { value: !0 });
       })();
     </script>

--- a/dist/samples/directions-panel/index.js
+++ b/dist/samples/directions-panel/index.js
@@ -5,6 +5,7 @@ function initMap() {
   const map = new google.maps.Map(document.getElementById("map"), {
     zoom: 7,
     center: { lat: 41.85, lng: -87.65 },
+    disableDefaultUI: true,
   });
   directionsRenderer.setMap(map);
   directionsRenderer.setPanel(document.getElementById("right-panel"));

--- a/dist/samples/directions-panel/inline.html
+++ b/dist/samples/directions-panel/inline.html
@@ -91,6 +91,7 @@
         const map = new google.maps.Map(document.getElementById("map"), {
           zoom: 7,
           center: { lat: 41.85, lng: -87.65 },
+          disableDefaultUI: true,
         });
         directionsRenderer.setMap(map);
         directionsRenderer.setPanel(document.getElementById("right-panel"));

--- a/dist/samples/directions-panel/jsfiddle.js
+++ b/dist/samples/directions-panel/jsfiddle.js
@@ -4,6 +4,7 @@ function initMap() {
   const map = new google.maps.Map(document.getElementById("map"), {
     zoom: 7,
     center: { lat: 41.85, lng: -87.65 },
+    disableDefaultUI: true,
   });
   directionsRenderer.setMap(map);
   directionsRenderer.setPanel(document.getElementById("right-panel"));

--- a/samples/directions-panel/src/index.ts
+++ b/samples/directions-panel/src/index.ts
@@ -23,6 +23,7 @@ function initMap(): void {
     {
       zoom: 7,
       center: { lat: 41.85, lng: -87.65 },
+      disableDefaultUi: true,
     }
   );
   directionsRenderer.setMap(map);

--- a/samples/directions-panel/src/index.ts
+++ b/samples/directions-panel/src/index.ts
@@ -23,7 +23,7 @@ function initMap(): void {
     {
       zoom: 7,
       center: { lat: 41.85, lng: -87.65 },
-      disableDefaultUi: true,
+      disableDefaultUI: true,
     }
   );
   directionsRenderer.setMap(map);


### PR DESCRIPTION
The Directions Panel sample does not require any default map controls, and looks much better without them. This fix adds the  `disableDefaultUi: true` property, for a visually cleaner sample.

Fixes #727 🦕
