### PR TITLE
fix:adds address to example request, fixes weird button artifacts

### DIFF
--- a/dist/samples/geocoding-component-restriction/iframe.html
+++ b/dist/samples/geocoding-component-restriction/iframe.html
@@ -84,7 +84,6 @@
 
 <div id="iframe-contents">
   <div id="floating-panel">
-    <code>address: "483 George St.",</code><br />
     <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
     ><br />
     <button id="submit">Geocode</button>

--- a/dist/samples/geocoding-component-restriction/iframe.html
+++ b/dist/samples/geocoding-component-restriction/iframe.html
@@ -84,7 +84,9 @@
 
 <div id="iframe-contents">
   <div id="floating-panel">
-    <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
+    <code>address: "483 George St.",</code><br />
+    <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
+    ><br />
     <button id="submit">Geocode</button>
   </div>
   <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/iframe.html
+++ b/dist/samples/geocoding-component-restriction/iframe.html
@@ -56,7 +56,10 @@
       document.getElementById("submit").addEventListener("click", () => {
         !(function (e, o) {
           e.geocode(
-            { componentRestrictions: { country: "AU", postalCode: "2000" } },
+            {
+              address: "483 George St.",
+              componentRestrictions: { country: "AU", postalCode: "2000" },
+            },
             (e, t) => {
               "OK" === t
                 ? (o.setCenter(e[0].geometry.location),
@@ -81,7 +84,7 @@
 
 <div id="iframe-contents">
   <div id="floating-panel">
-    <pre>componentRestrictions: {country: "AU", postalCode: "2000"}</pre>
+    <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
     <button id="submit">Geocode</button>
   </div>
   <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/index.html
+++ b/dist/samples/geocoding-component-restriction/index.html
@@ -63,6 +63,7 @@
             !(function (e, o) {
               e.geocode(
                 {
+                  address: "483 George St.",
                   componentRestrictions: { country: "AU", postalCode: "2000" },
                 },
                 (e, t) => {
@@ -90,7 +91,7 @@
   </head>
   <body>
     <div id="floating-panel">
-      <pre>componentRestrictions: {country: "AU", postalCode: "2000"}</pre>
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/index.html
+++ b/dist/samples/geocoding-component-restriction/index.html
@@ -91,7 +91,6 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>address: "483 George St.",</code><br />
       <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
       ><br />
       <button id="submit">Geocode</button>

--- a/dist/samples/geocoding-component-restriction/index.html
+++ b/dist/samples/geocoding-component-restriction/index.html
@@ -91,7 +91,9 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
+      <code>address: "483 George St.",</code><br />
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
+      ><br />
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/index.js
+++ b/dist/samples/geocoding-component-restriction/index.js
@@ -13,6 +13,7 @@ function initMap() {
 function geocodeAddress(geocoder, map) {
   geocoder.geocode(
     {
+      address: "483 George St.",
       componentRestrictions: {
         country: "AU",
         postalCode: "2000",

--- a/dist/samples/geocoding-component-restriction/inline.html
+++ b/dist/samples/geocoding-component-restriction/inline.html
@@ -72,7 +72,9 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
+      <code>address: "483 George St.",</code><br />
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
+      ><br />
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/inline.html
+++ b/dist/samples/geocoding-component-restriction/inline.html
@@ -72,7 +72,6 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>address: "483 George St.",</code><br />
       <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
       ><br />
       <button id="submit">Geocode</button>

--- a/dist/samples/geocoding-component-restriction/inline.html
+++ b/dist/samples/geocoding-component-restriction/inline.html
@@ -47,6 +47,7 @@
       function geocodeAddress(geocoder, map) {
         geocoder.geocode(
           {
+            address: "483 George St.",
             componentRestrictions: {
               country: "AU",
               postalCode: "2000",
@@ -71,7 +72,7 @@
   </head>
   <body>
     <div id="floating-panel">
-      <pre>componentRestrictions: {country: "AU", postalCode: "2000"}</pre>
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/jsfiddle.html
+++ b/dist/samples/geocoding-component-restriction/jsfiddle.html
@@ -7,7 +7,6 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>address: "483 George St.",</code><br />
       <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
       ><br />
       <button id="submit">Geocode</button>

--- a/dist/samples/geocoding-component-restriction/jsfiddle.html
+++ b/dist/samples/geocoding-component-restriction/jsfiddle.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div id="floating-panel">
-      <pre>componentRestrictions: {country: "AU", postalCode: "2000"}</pre>
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/jsfiddle.html
+++ b/dist/samples/geocoding-component-restriction/jsfiddle.html
@@ -7,7 +7,9 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
+      <code>address: "483 George St.",</code><br />
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
+      ><br />
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/jsfiddle.js
+++ b/dist/samples/geocoding-component-restriction/jsfiddle.js
@@ -12,6 +12,7 @@ function initMap() {
 function geocodeAddress(geocoder, map) {
   geocoder.geocode(
     {
+      address: "483 George St.",
       componentRestrictions: {
         country: "AU",
         postalCode: "2000",

--- a/dist/samples/geocoding-component-restriction/sample.html
+++ b/dist/samples/geocoding-component-restriction/sample.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <div id="floating-panel">
-      <pre>componentRestrictions: {country: "AU", postalCode: "2000"}</pre>
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/dist/samples/geocoding-component-restriction/sample.html
+++ b/dist/samples/geocoding-component-restriction/sample.html
@@ -9,7 +9,6 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>address: "483 George St.",</code><br />
       <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
       ><br />
       <button id="submit">Geocode</button>

--- a/dist/samples/geocoding-component-restriction/sample.html
+++ b/dist/samples/geocoding-component-restriction/sample.html
@@ -9,7 +9,9 @@
   </head>
   <body>
     <div id="floating-panel">
-      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
+      <code>address: "483 George St.",</code><br />
+      <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code
+      ><br />
       <button id="submit">Geocode</button>
     </div>
     <div id="map"></div>

--- a/samples/geocoding-component-restriction/src/index.njk
+++ b/samples/geocoding-component-restriction/src/index.njk
@@ -15,7 +15,6 @@
 -->
 {% extends '../../../shared/layout.njk'%} {% block html %}
 <div id="floating-panel">
-  <code>address: "483 George St.",</code><br/>
   <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code><br/>
   <button id="submit">Geocode</button>
 </div>

--- a/samples/geocoding-component-restriction/src/index.njk
+++ b/samples/geocoding-component-restriction/src/index.njk
@@ -15,7 +15,7 @@
 -->
 {% extends '../../../shared/layout.njk'%} {% block html %}
 <div id="floating-panel">
-  <pre>componentRestrictions: {country: "AU", postalCode: "2000"}</pre>
+  <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
   <button id="submit">Geocode</button>
 </div>
 <div id="map"></div>

--- a/samples/geocoding-component-restriction/src/index.njk
+++ b/samples/geocoding-component-restriction/src/index.njk
@@ -15,7 +15,8 @@
 -->
 {% extends '../../../shared/layout.njk'%} {% block html %}
 <div id="floating-panel">
-  <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code>
+  <code>address: "483 George St.",</code><br/>
+  <code>componentRestrictions: {country: "AU", postalCode: "2000"}</code><br/>
   <button id="submit">Geocode</button>
 </div>
 <div id="map"></div>

--- a/samples/geocoding-component-restriction/src/index.ts
+++ b/samples/geocoding-component-restriction/src/index.ts
@@ -38,6 +38,7 @@ function initMap(): void {
 function geocodeAddress(geocoder: google.maps.Geocoder, map: google.maps.Map) {
   geocoder.geocode(
     {
+      address: "483 George St.",
       componentRestrictions: {
         country: "AU",
         postalCode: "2000",


### PR DESCRIPTION
This fix:
1. Adds an address to the Geocoding request, so that it works.
2. Changes `pre` to `code` to prevent DevSite elements from partially rendering in custom control.

Fixes #733 🦕
