### PR TITLE
feat: store locator sample add 45-degree map view when viewing location details

### DIFF
--- a/dist/samples/store-locator/iframe.html
+++ b/dist/samples/store-locator/iframe.html
@@ -121,9 +121,6 @@
           mapTypeId: a,
           zoom: 10,
         })),
-        n.addListener("zoom_changed", () => {
-          n.getZoom() < 19 && (n.setTilt(0), n.setMapTypeId(a));
-        }),
         new mdc.textField.MDCTextField(
           document.querySelector(".mdc-text-field")
         ),
@@ -137,33 +134,38 @@
           .then((e) => e.json())
           .then((e) => {
             const t = e.features,
-              a = [];
+              o = [];
             t.forEach(
               ({ attributes: { NAME: e }, geometry: { x: t, y: n } }) => {
                 c.push({ name: e, location: { lat: n, lng: t }, address: "" });
-                const o = new google.maps.Marker({
+                const a = new google.maps.Marker({
                   position: { lat: n, lng: t },
                 });
-                o.addListener("click", () => {
-                  p(new google.maps.LatLng({ lat: n, lng: t }));
+                a.addListener("click", () => {
+                  g(new google.maps.LatLng({ lat: n, lng: t })),
+                    p(new google.maps.LatLng({ lat: n, lng: t }));
                 }),
-                  a.push(o);
+                  o.push(a);
               }
             ),
-              new MarkerClusterer(n, a, {
+              new MarkerClusterer(n, o, {
                 imagePath:
                   "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",
               }),
               window.addEventListener("load", () => {
                 (void 0).done();
               }),
-              g(n.getCenter());
+              g(n.getCenter()),
+              n.setZoom(13),
+              n.setMapTypeId(a);
           }),
         document.getElementById("near-me").addEventListener("click", () => {
           navigator.geolocation &&
             navigator.geolocation.getCurrentPosition(
               ({ coords: { latitude: e, longitude: t } }) => {
-                g(new google.maps.LatLng({ lat: e, lng: t }));
+                g(new google.maps.LatLng({ lat: e, lng: t })),
+                  n.setZoom(10),
+                  n.setMapTypeId(a);
               }
             );
         }),
@@ -172,7 +174,10 @@
         });
     }
     function m() {
-      (s.disabled = !0), g(r.getPlace().geometry.location);
+      (s.disabled = !0),
+        g(r.getPlace().geometry.location),
+        n.setZoom(10),
+        n.setMapTypeId(a);
     }
     function g(e) {
       e &&
@@ -181,8 +186,6 @@
           : ((s.disabled = !0),
             (l = !0),
             n.setCenter(e),
-            n.setZoom(10),
-            n.setMapTypeId(a),
             c.forEach((e) => {
               delete e.travelDistance,
                 delete e.travelDistanceText,
@@ -257,9 +260,7 @@
                             s
                               .querySelector(".mdc-card__primary-action")
                               .addEventListener("click", () => {
-                                console.log("blah"),
-                                  console.log(n),
-                                  p(new google.maps.LatLng(n));
+                                p(new google.maps.LatLng(n));
                               }),
                             t.appendChild(s);
                         }
@@ -271,10 +272,16 @@
               })));
     }
     function p(e) {
-      g(e), n.setZoom(19), n.setMapTypeId(o), n.setTilt(45);
+      n.setCenter(e),
+        n.setZoom(19),
+        n.setMapTypeId(o),
+        n.setTilt(45),
+        google.maps.event.addListenerOnce(n, "zoom_changed", () => {
+          n.getZoom() < 19 && (n.setTilt(0), n.setMapTypeId(a));
+        });
     }
     var u = window;
-    for (var v in t) u[v] = t[v];
+    for (var y in t) u[y] = t[y];
     t.__esModule && Object.defineProperty(u, "__esModule", { value: !0 });
   })();
 </script>

--- a/dist/samples/store-locator/index.html
+++ b/dist/samples/store-locator/index.html
@@ -128,9 +128,6 @@
               mapTypeId: a,
               zoom: 10,
             })),
-            n.addListener("zoom_changed", () => {
-              n.getZoom() < 19 && (n.setTilt(0), n.setMapTypeId(a));
-            }),
             new mdc.textField.MDCTextField(
               document.querySelector(".mdc-text-field")
             ),
@@ -144,7 +141,7 @@
               .then((e) => e.json())
               .then((e) => {
                 const t = e.features,
-                  a = [];
+                  o = [];
                 t.forEach(
                   ({ attributes: { NAME: e }, geometry: { x: t, y: n } }) => {
                     c.push({
@@ -152,29 +149,34 @@
                       location: { lat: n, lng: t },
                       address: "",
                     });
-                    const o = new google.maps.Marker({
+                    const a = new google.maps.Marker({
                       position: { lat: n, lng: t },
                     });
-                    o.addListener("click", () => {
-                      p(new google.maps.LatLng({ lat: n, lng: t }));
+                    a.addListener("click", () => {
+                      g(new google.maps.LatLng({ lat: n, lng: t })),
+                        p(new google.maps.LatLng({ lat: n, lng: t }));
                     }),
-                      a.push(o);
+                      o.push(a);
                   }
                 ),
-                  new MarkerClusterer(n, a, {
+                  new MarkerClusterer(n, o, {
                     imagePath:
                       "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",
                   }),
                   window.addEventListener("load", () => {
                     (void 0).done();
                   }),
-                  g(n.getCenter());
+                  g(n.getCenter()),
+                  n.setZoom(13),
+                  n.setMapTypeId(a);
               }),
             document.getElementById("near-me").addEventListener("click", () => {
               navigator.geolocation &&
                 navigator.geolocation.getCurrentPosition(
                   ({ coords: { latitude: e, longitude: t } }) => {
-                    g(new google.maps.LatLng({ lat: e, lng: t }));
+                    g(new google.maps.LatLng({ lat: e, lng: t })),
+                      n.setZoom(10),
+                      n.setMapTypeId(a);
                   }
                 );
             }),
@@ -183,7 +185,10 @@
             });
         }
         function m() {
-          (s.disabled = !0), g(r.getPlace().geometry.location);
+          (s.disabled = !0),
+            g(r.getPlace().geometry.location),
+            n.setZoom(10),
+            n.setMapTypeId(a);
         }
         function g(e) {
           e &&
@@ -192,8 +197,6 @@
               : ((s.disabled = !0),
                 (l = !0),
                 n.setCenter(e),
-                n.setZoom(10),
-                n.setMapTypeId(a),
                 c.forEach((e) => {
                   delete e.travelDistance,
                     delete e.travelDistanceText,
@@ -268,9 +271,7 @@
                                 s
                                   .querySelector(".mdc-card__primary-action")
                                   .addEventListener("click", () => {
-                                    console.log("blah"),
-                                      console.log(n),
-                                      p(new google.maps.LatLng(n));
+                                    p(new google.maps.LatLng(n));
                                   }),
                                 t.appendChild(s);
                             }
@@ -282,10 +283,16 @@
                   })));
         }
         function p(e) {
-          g(e), n.setZoom(19), n.setMapTypeId(o), n.setTilt(45);
+          n.setCenter(e),
+            n.setZoom(19),
+            n.setMapTypeId(o),
+            n.setTilt(45),
+            google.maps.event.addListenerOnce(n, "zoom_changed", () => {
+              n.getZoom() < 19 && (n.setTilt(0), n.setMapTypeId(a));
+            });
         }
         var u = window;
-        for (var v in t) u[v] = t[v];
+        for (var y in t) u[y] = t[y];
         t.__esModule && Object.defineProperty(u, "__esModule", { value: !0 });
       })();
     </script>

--- a/dist/samples/store-locator/inline.html
+++ b/dist/samples/store-locator/inline.html
@@ -115,14 +115,6 @@
           mapTypeId: originalMapTypeId,
           zoom: 10,
         });
-        map.addListener("zoom_changed", () => {
-          const newZoom = map.getZoom();
-
-          if (newZoom < 19) {
-            map.setTilt(0);
-            map.setMapTypeId(originalMapTypeId);
-          }
-        });
         new mdc.textField.MDCTextField(
           document.querySelector(".mdc-text-field")
         );
@@ -152,6 +144,9 @@
                   position: { lat, lng },
                 });
                 marker.addListener("click", () => {
+                  // Update the list of nearby locations in the sidebar
+                  update(new google.maps.LatLng({ lat, lng }));
+                  // Update the camera of the map
                   seeDetail(new google.maps.LatLng({ lat, lng }));
                 });
                 markers.push(marker);
@@ -166,12 +161,16 @@
               progress.done();
             });
             update(map.getCenter());
+            map.setZoom(13);
+            map.setMapTypeId(originalMapTypeId);
           });
         document.getElementById("near-me").addEventListener("click", () => {
           if (navigator.geolocation) {
             navigator.geolocation.getCurrentPosition(
               ({ coords: { latitude: lat, longitude: lng } }) => {
                 update(new google.maps.LatLng({ lat, lng }));
+                map.setZoom(10);
+                map.setMapTypeId(originalMapTypeId);
               }
             );
           }
@@ -229,8 +228,6 @@
               card
                 .querySelector(".mdc-card__primary-action")
                 .addEventListener("click", () => {
-                  console.log("blah");
-                  console.log(location);
                   seeDetail(new google.maps.LatLng(location));
                 });
               cardsDiv.appendChild(card);
@@ -266,6 +263,8 @@
         const placeResult = autocomplete.getPlace();
         const location = placeResult.geometry.location;
         update(location);
+        map.setZoom(10);
+        map.setMapTypeId(originalMapTypeId);
       }
 
       function update(location) {
@@ -280,8 +279,6 @@
         autocompleteInput.disabled = true;
         isUpdateInProgress = true;
         map.setCenter(location);
-        map.setZoom(10);
-        map.setMapTypeId(originalMapTypeId);
         // reset values
         stores.forEach((store) => {
           delete store.travelDistance;
@@ -323,12 +320,22 @@
           });
       }
 
+      // [START maps_store_locator_45]
       function seeDetail(location) {
-        update(location);
+        map.setCenter(location);
         map.setZoom(19);
         map.setMapTypeId(detailMapTypeId);
         map.setTilt(45);
+        google.maps.event.addListenerOnce(map, "zoom_changed", () => {
+          const newZoom = map.getZoom();
+
+          if (newZoom < 19) {
+            map.setTilt(0);
+            map.setMapTypeId(originalMapTypeId);
+          }
+        });
       }
+      // [END maps_store_locator_45]
     </script>
   </head>
   <body>

--- a/dist/samples/store-locator/jsfiddle.js
+++ b/dist/samples/store-locator/jsfiddle.js
@@ -18,14 +18,6 @@ function initMap() {
     mapTypeId: originalMapTypeId,
     zoom: 10,
   });
-  map.addListener("zoom_changed", () => {
-    const newZoom = map.getZoom();
-
-    if (newZoom < 19) {
-      map.setTilt(0);
-      map.setMapTypeId(originalMapTypeId);
-    }
-  });
   new mdc.textField.MDCTextField(document.querySelector(".mdc-text-field"));
   autocompleteInput = document.getElementById("search-input");
   autocomplete = new google.maps.places.Autocomplete(autocompleteInput, {});
@@ -45,6 +37,9 @@ function initMap() {
           stores.push({ name, location: { lat, lng }, address: "" });
           const marker = new google.maps.Marker({ position: { lat, lng } });
           marker.addListener("click", () => {
+            // Update the list of nearby locations in the sidebar
+            update(new google.maps.LatLng({ lat, lng }));
+            // Update the camera of the map
             seeDetail(new google.maps.LatLng({ lat, lng }));
           });
           markers.push(marker);
@@ -59,12 +54,16 @@ function initMap() {
         progress.done();
       });
       update(map.getCenter());
+      map.setZoom(13);
+      map.setMapTypeId(originalMapTypeId);
     });
   document.getElementById("near-me").addEventListener("click", () => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         ({ coords: { latitude: lat, longitude: lng } }) => {
           update(new google.maps.LatLng({ lat, lng }));
+          map.setZoom(10);
+          map.setMapTypeId(originalMapTypeId);
         }
       );
     }
@@ -116,8 +115,6 @@ function renderCards(stores) {
         card
           .querySelector(".mdc-card__primary-action")
           .addEventListener("click", () => {
-            console.log("blah");
-            console.log(location);
             seeDetail(new google.maps.LatLng(location));
           });
         cardsDiv.appendChild(card);
@@ -153,6 +150,8 @@ function placeChanged() {
   const placeResult = autocomplete.getPlace();
   const location = placeResult.geometry.location;
   update(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
 }
 
 function update(location) {
@@ -167,8 +166,6 @@ function update(location) {
   autocompleteInput.disabled = true;
   isUpdateInProgress = true;
   map.setCenter(location);
-  map.setZoom(10);
-  map.setMapTypeId(originalMapTypeId);
   // reset values
   stores.forEach((store) => {
     delete store.travelDistance;
@@ -208,9 +205,19 @@ function update(location) {
     });
 }
 
+// [START maps_store_locator_45]
 function seeDetail(location) {
-  update(location);
+  map.setCenter(location);
   map.setZoom(19);
   map.setMapTypeId(detailMapTypeId);
   map.setTilt(45);
+  google.maps.event.addListenerOnce(map, "zoom_changed", () => {
+    const newZoom = map.getZoom();
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
 }
+// [END maps_store_locator_45]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2862,9 +2862,9 @@
       }
     },
     "@types/google.maps": {
-      "version": "3.45.2",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.45.2.tgz",
-      "integrity": "sha512-3hKhaLt4EcKzssjmpIH8M12tN8WHp/gz7lh+85NdwXGtGSAjtiOEG4st9XdvaZkUHtlNaiAP2PlDbkNnNmD2NQ==",
+      "version": "3.45.3",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.45.3.tgz",
+      "integrity": "sha512-UZHD7qch+44XFNbx/Fjf6NtdpScRWRhfCenvv/pMJfuJ4KQMzapDLqj/OOyHpB8nDp1ilNL3ujPYLY1YZHq1yQ==",
       "dev": true
     },
     "@types/google.visualization": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@tweenjs/tween.js": "^18.6.4",
-    "@types/google.maps": "^3.44.6",
+    "@types/google.maps": "^3.45.3",
     "@types/google.visualization": "0.0.66",
     "@types/jest": "^26.0.23",
     "@types/three": "^0.129.0",

--- a/samples/samples.bzl
+++ b/samples/samples.bzl
@@ -154,6 +154,7 @@ SAMPLES = [
     "rectangle-simple",
     "rectangle-zoom",
     "split-map-panes",
+    "store-locator",
     "streetview-controls",
     "streetview-custom-simple",
     "streetview-custom-tiles",

--- a/samples/store-locator/BUILD.bazel
+++ b/samples/store-locator/BUILD.bazel
@@ -1,0 +1,16 @@
+ # Copyright 2021 Google LLC. All Rights Reserved.
+ # 
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ # 
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ # 
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+load("//rules:sample.bzl", "sample")
+
+sample(name = "store-locator")

--- a/samples/store-locator/package.json
+++ b/samples/store-locator/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "store-locator",
+  "title": "Store Locator",
+  "callback": "initMap",
+  "libraries": [
+    "places",
+    "geometry"
+  ],
+  "version": "weekly",
+  "tag": "store_locator"
+}

--- a/samples/store-locator/src/index.njk
+++ b/samples/store-locator/src/index.njk
@@ -1,0 +1,48 @@
+<!--
+  Copyright 2019 Google LLC. All Rights Reserved.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+{% extends '../../../shared/layout.njk'%}
+{% block external %}
+  <link href="https://unpkg.com/material-components-web@6.0.0/dist/material-components-web.css" rel="stylesheet">
+  <script src="https://unpkg.com/material-components-web@6.0.0/dist/material-components-web.min.js"></script>
+  <script src="https://unpkg.com/@google/markerclustererplus@^4.0.1/dist/markerclustererplus.min.js"></script>
+  <head>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+</head>
+{% endblock %}
+{% block html %}
+  <div id="container">
+    <div id="map"></div>
+    <div id="sidebar">
+      <div id="search">
+        <label class="mdc-text-field mdc-text-field--outlined">
+          <input type="text" class="mdc-text-field__input" aria-labelledby="my-label-id" id="search-input">
+          <span class="mdc-notched-outline">
+            <span class="mdc-notched-outline__leading"></span>
+            <span class="mdc-notched-outline__notch">
+              <span class="mdc-floating-label" id="my-label-id">Enter a location</span>
+            </span>
+            <span class="mdc-notched-outline__trailing"></span>
+          </span>
+        </label>
+        <button id="near-me" class="mdc-icon-button material-icons">near_me</button>
+        <button id="refresh" class="mdc-icon-button material-icons">refresh</button>
+      </div>
+      <div id="cards">
+          {% include '../../../shared/progress-circular.njk' %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/samples/store-locator/src/index.ts
+++ b/samples/store-locator/src/index.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// [START maps_store_locator]
+let map: google.maps.Map;
+let originalMapTypeId: google.maps.MapTypeId;
+let detailMapTypeId: google.maps.MapTypeId;
+let autocomplete: google.maps.places.Autocomplete;
+let autocompleteInput: HTMLInputElement;
+let distanceMatrixService: google.maps.DistanceMatrixService;
+let progress: any;
+let isUpdateInProgress = false;
+
+interface Store {
+  name: string;
+  address?: string;
+  location: google.maps.LatLngLiteral;
+  distance?: number;
+  travelDistance?: number;
+  travelDistanceText?: string;
+  travelDuration?: number;
+  travelDurationText?: string;
+}
+
+const stores: Store[] = [];
+
+// Initialize and add the map
+function initMap(): void {
+  distanceMatrixService = new google.maps.DistanceMatrixService();
+  originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+  detailMapTypeId = google.maps.MapTypeId.HYBRID;
+
+  map = new google.maps.Map(document.getElementById("map") as HTMLElement, {
+    center: { lat: 39.79, lng: -104.98 },
+    mapTypeId: originalMapTypeId,
+    zoom: 10,
+  });
+
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom()!;
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
+
+  // @ts-ignore
+  new mdc.textField.MDCTextField(
+    document.querySelector(".mdc-text-field") as HTMLInputElement
+  );
+
+  autocompleteInput = document.getElementById(
+    "search-input"
+  ) as HTMLInputElement;
+  autocomplete = new google.maps.places.Autocomplete(autocompleteInput, {});
+  autocomplete.addListener("place_changed", placeChanged);
+  autocomplete.bindTo("bounds", map); // bias to map viewport
+
+  fetch(
+    "https://carto.nationalmap.gov/arcgis/rest/services/structures/MapServer/23/query?where=STATE%3D%27CO%27&returnGeometry=true&outSR=4326&f=pjson"
+  )
+    .then((response) => {
+      return response.json();
+    })
+    .then((data) => {
+      const features: {
+        attributes: { NAME: string };
+        geometry: { x: number; y: number };
+      }[] = data.features;
+
+      const markers: google.maps.Marker[] = [];
+
+      features.forEach(
+        ({ attributes: { NAME: name }, geometry: { x: lng, y: lat } }) => {
+          stores.push({ name, location: { lat, lng }, address: "" });
+          const marker = new google.maps.Marker({ position: { lat, lng } });
+          marker.addListener("click", () => {
+            seeDetail(new google.maps.LatLng({ lat, lng }));
+          });
+          markers.push(marker);
+        }
+      );
+
+      // @ts-ignore
+      new MarkerClusterer(map, markers, {
+        imagePath:
+          "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",
+      });
+
+      // initMap may be called before all JS has been parsed and executed when using the async attribute
+      window.addEventListener("load", () => {
+        progress.done();
+      });
+
+      update(map.getCenter()!);
+    });
+
+  (document.getElementById("near-me") as HTMLButtonElement).addEventListener(
+    "click",
+    () => {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          ({ coords: { latitude: lat, longitude: lng } }) => {
+            update(new google.maps.LatLng({ lat, lng }));
+          }
+        );
+      }
+    }
+  );
+
+  (document.getElementById("refresh") as HTMLButtonElement).addEventListener(
+    "click",
+    () => {
+      update(map.getCenter()!);
+    }
+  );
+}
+
+function renderCards(stores: Store[]): void {
+  const cardsDiv = document.getElementById("cards") as HTMLElement;
+  cardsDiv.innerHTML = "";
+
+  stores
+    .slice(0, 25)
+    .forEach(
+      ({ name, location, address, travelDistanceText, travelDurationText }) => {
+        const card = document.createElement("div");
+        card.classList.add("mdc-card", "mdc-card--outlined");
+
+        card.innerHTML = `
+<div class="mdc-card__primary-action">
+  <div id="card-header">
+    <h2 class="mdc-typography--headline6">${name}</h2>
+  </div>
+</div>
+<div id="card-body">
+  </div>
+<div class="mdc-card__actions">
+  <a class="mdc-button mdc-card__action mdc-card__action--button"
+    target="_blank" href="https://maps.google.com?q=${
+      address ? address : name
+    }">
+    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__label">Directions</span>
+  </a>
+  <button class="mdc-button mdc-card__action mdc-card__action--button">
+    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__label">More Information</span>
+  </button>
+</div>`;
+
+        const cardBody = card.querySelector("#card-body") as HTMLElement;
+
+        if (address) {
+          cardBody.innerHTML = `<h2 class="mdc-typography--body1">${address}</h2>`;
+        }
+
+        if (travelDistanceText) {
+          cardBody.innerHTML += `<h2 class="mdc-typography--body2">${travelDistanceText}, ${travelDurationText}</h2>`;
+        }
+
+        (
+          card.querySelector(".mdc-card__primary-action") as HTMLElement
+        ).addEventListener("click", () => {
+          console.log("blah");
+          console.log(location);
+          seeDetail(new google.maps.LatLng(location));
+        });
+
+        cardsDiv.appendChild(card);
+      }
+    );
+  cardsDiv.scrollTo(0, 0);
+}
+
+function getDistances(
+  place: google.maps.Place | google.maps.LatLng
+): Promise<google.maps.DistanceMatrixResponse> {
+  const origins = [place];
+
+  return new Promise((resolve, reject) => {
+    const callback = (
+      response: google.maps.DistanceMatrixResponse | null,
+      status: google.maps.DistanceMatrixStatus
+    ) => {
+      if (status === google.maps.DistanceMatrixStatus.OK && response) {
+        resolve(response);
+      } else {
+        reject(status);
+      }
+    };
+
+    distanceMatrixService.getDistanceMatrix(
+      {
+        origins,
+        destinations: stores.slice(0, 25).map((store) => store.location),
+        travelMode: google.maps.TravelMode.DRIVING,
+        unitSystem: google.maps.UnitSystem.IMPERIAL,
+      },
+      callback
+    );
+  });
+}
+
+function placeChanged() {
+  autocompleteInput.disabled = true;
+  const placeResult = autocomplete.getPlace();
+  const location = (placeResult.geometry as google.maps.places.PlaceGeometry)
+    .location;
+
+  update(location);
+}
+
+function update(location?: google.maps.LatLng) {
+  if (!location) {
+    return;
+  }
+
+  if (isUpdateInProgress) {
+    alert("Update in progress, please try again.");
+    return;
+  }
+
+  autocompleteInput.disabled = true;
+  isUpdateInProgress = true;
+  map.setCenter(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
+
+  // reset values
+  stores.forEach((store) => {
+    delete store.travelDistance;
+    delete store.travelDistanceText;
+    delete store.travelDuration;
+    delete store.travelDurationText;
+  });
+
+  // sort by distance
+  stores.sort((a, b) => {
+    return (
+      google.maps.geometry.spherical.computeDistanceBetween(
+        new google.maps.LatLng(a.location),
+        location
+      ) -
+      google.maps.geometry.spherical.computeDistanceBetween(
+        new google.maps.LatLng(b.location),
+        location
+      )
+    );
+  });
+
+  getDistances(location)
+    .then((response) => {
+      for (let i = 0; i < response.rows[0].elements.length; i++) {
+        stores[i].address = response.destinationAddresses[i];
+        stores[i].travelDistance = response.rows[0].elements[i].distance.value;
+        stores[i].travelDistanceText =
+          response.rows[0].elements[i].distance.text;
+        stores[i].travelDuration = response.rows[0].elements[i].duration.value;
+        stores[i].travelDurationText =
+          response.rows[0].elements[i].duration.text;
+      }
+    })
+    .finally(() => {
+      renderCards(stores);
+      autocompleteInput.disabled = false;
+      isUpdateInProgress = false;
+    });
+}
+
+function seeDetail(location: google.maps.LatLng) {
+  update(location);
+  map.setZoom(19);
+  map.setMapTypeId(detailMapTypeId);
+  map.setTilt(45);
+}
+
+// [END maps_store_locator]
+export { initMap };

--- a/samples/store-locator/src/index.ts.orig
+++ b/samples/store-locator/src/index.ts.orig
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// [START maps_store_locator]
+let map: google.maps.Map;
+let originalMapTypeId: google.maps.MapTypeId;
+let detailMapTypeId: google.maps.MapTypeId;
+let autocomplete: google.maps.places.Autocomplete;
+let autocompleteInput: HTMLInputElement;
+let distanceMatrixService: google.maps.DistanceMatrixService;
+let progress: any;
+let isUpdateInProgress = false;
+
+interface Store {
+  name: string;
+  address?: string;
+  location: google.maps.LatLngLiteral;
+  distance?: number;
+  travelDistance?: number;
+  travelDistanceText?: string;
+  travelDuration?: number;
+  travelDurationText?: string;
+}
+
+const stores: Store[] = [];
+
+// Initialize and add the map
+function initMap(): void {
+  distanceMatrixService = new google.maps.DistanceMatrixService();
+  originalMapTypeId = google.maps.MapTypeId.ROADMAP;
+  detailMapTypeId = google.maps.MapTypeId.HYBRID;
+
+  map = new google.maps.Map(document.getElementById("map") as HTMLElement, {
+    center: { lat: 39.79, lng: -104.98 },
+    mapTypeId: originalMapTypeId,
+    zoom: 10,
+  });
+
+  // @ts-ignore
+  new mdc.textField.MDCTextField(
+    document.querySelector(".mdc-text-field") as HTMLInputElement
+  );
+
+  autocompleteInput = document.getElementById(
+    "search-input"
+  ) as HTMLInputElement;
+  autocomplete = new google.maps.places.Autocomplete(autocompleteInput, {});
+  autocomplete.addListener("place_changed", placeChanged);
+  autocomplete.bindTo("bounds", map); // bias to map viewport
+
+  fetch(
+    "https://carto.nationalmap.gov/arcgis/rest/services/structures/MapServer/23/query?where=STATE%3D%27CO%27&returnGeometry=true&outSR=4326&f=pjson"
+  )
+    .then((response) => {
+      return response.json();
+    })
+    .then((data) => {
+      const features: {
+        attributes: { NAME: string };
+        geometry: { x: number; y: number };
+      }[] = data.features;
+
+      const markers: google.maps.Marker[] = [];
+
+      features.forEach(
+        ({ attributes: { NAME: name }, geometry: { x: lng, y: lat } }) => {
+          stores.push({ name, location: { lat, lng }, address: "" });
+          const marker = new google.maps.Marker({ position: { lat, lng } });
+          marker.addListener("click", () => {
+            seeDetail(new google.maps.LatLng({ lat, lng }));
+          });
+          markers.push(marker);
+        }
+      );
+
+      // @ts-ignore
+      new MarkerClusterer(map, markers, {
+        imagePath:
+          "https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/m",
+      });
+
+      progress.done();
+
+      update(map.getCenter()!);
+    });
+
+  (document.getElementById("near-me") as HTMLButtonElement).addEventListener(
+    "click",
+    () => {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          ({ coords: { latitude: lat, longitude: lng } }) => {
+            update(new google.maps.LatLng({ lat, lng }));
+          }
+        );
+      }
+    }
+  );
+
+  (document.getElementById("refresh") as HTMLButtonElement).addEventListener(
+    "click",
+    () => {
+      update(map.getCenter()!);
+    }
+  );
+}
+
+function renderCards(stores: Store[]): void {
+  const cardsDiv = document.getElementById("cards") as HTMLElement;
+  cardsDiv.innerHTML = "";
+
+  stores
+    .slice(0, 25)
+    .forEach(
+      ({ name, location, address, travelDistanceText, travelDurationText }) => {
+        const card = document.createElement("div");
+        card.classList.add("mdc-card", "mdc-card--outlined");
+
+        card.innerHTML = `
+<div class="mdc-card__primary-action">
+  <div id="card-header">
+    <h2 class="mdc-typography--headline6">${name}</h2>
+  </div>
+</div>
+<div id="card-body">
+  </div>
+<div class="mdc-card__actions">
+  <a class="mdc-button mdc-card__action mdc-card__action--button"
+    target="_blank" href="https://maps.google.com?q=${
+      address ? address : name
+    }">
+    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__label">Directions</span>
+  </a>
+  <button class="mdc-button mdc-card__action mdc-card__action--button">
+    <div class="mdc-button__ripple"></div>
+    <span class="mdc-button__label">More Information</span>
+  </button>
+</div>`;
+
+        const cardBody = card.querySelector("#card-body") as HTMLElement;
+
+        if (address) {
+          cardBody.innerHTML = `<h2 class="mdc-typography--body1">${address}</h2>`;
+        }
+
+        if (travelDistanceText) {
+          cardBody.innerHTML += `<h2 class="mdc-typography--body2">${travelDistanceText}, ${travelDurationText}</h2>`;
+        }
+
+        (card.querySelector(
+          ".mdc-card__primary-action"
+        ) as HTMLElement).addEventListener("click", () => {
+          seeDetail(new google.maps.LatLng(location));
+        });
+
+        cardsDiv.appendChild(card);
+      }
+    );
+  cardsDiv.scrollTo(0, 0);
+}
+
+function getDistances(
+  place: google.maps.Place | google.maps.LatLng
+): Promise<google.maps.DistanceMatrixResponse> {
+  const origins = [place];
+
+  return new Promise((resolve, reject) => {
+    const callback = (
+      response: google.maps.DistanceMatrixResponse | null,
+      status: google.maps.DistanceMatrixStatus
+    ) => {
+      if (status === google.maps.DistanceMatrixStatus.OK && response) {
+        resolve(response);
+      } else {
+        reject(status);
+      }
+    };
+
+    distanceMatrixService.getDistanceMatrix(
+      {
+        origins,
+        destinations: stores.slice(0, 25).map((store) => store.location),
+        travelMode: google.maps.TravelMode.DRIVING,
+        unitSystem: google.maps.UnitSystem.IMPERIAL,
+      },
+      callback
+    );
+  });
+}
+
+function placeChanged() {
+  autocompleteInput.disabled = true;
+  const placeResult = autocomplete.getPlace();
+  const location = (placeResult.geometry as google.maps.places.PlaceGeometry)
+    .location;
+
+  update(location);
+}
+
+function update(location?: google.maps.LatLng) {
+  if (!location) {
+    return;
+  }
+
+  if (isUpdateInProgress) {
+    alert("Update in progress, please try again.");
+    return;
+  }
+
+  autocompleteInput.disabled = true;
+  isUpdateInProgress = true;
+  map.setCenter(location);
+  map.setZoom(10);
+  map.setMapTypeId(originalMapTypeId);
+
+  // reset values
+  stores.forEach((store) => {
+    delete store.travelDistance;
+    delete store.travelDistanceText;
+    delete store.travelDuration;
+    delete store.travelDurationText;
+  });
+
+  // sort by distance
+  stores.sort((a, b) => {
+    return (
+      google.maps.geometry.spherical.computeDistanceBetween(
+        new google.maps.LatLng(a.location),
+        location
+      ) -
+      google.maps.geometry.spherical.computeDistanceBetween(
+        new google.maps.LatLng(b.location),
+        location
+      )
+    );
+  });
+
+  getDistances(location)
+    .then((response) => {
+      for (let i = 0; i < response.rows[0].elements.length; i++) {
+        stores[i].address = response.destinationAddresses[i];
+        stores[i].travelDistance = response.rows[0].elements[i].distance.value;
+        stores[i].travelDistanceText =
+          response.rows[0].elements[i].distance.text;
+        stores[i].travelDuration = response.rows[0].elements[i].duration.value;
+        stores[i].travelDurationText =
+          response.rows[0].elements[i].duration.text;
+      }
+    })
+    .finally(() => {
+      renderCards(stores);
+      autocompleteInput.disabled = false;
+      isUpdateInProgress = false;
+    });
+}
+
+function seeDetail(location: google.maps.LatLng) {
+  update(location);
+  map.setZoom(19);
+  map.setMapTypeId(detailMapTypeId);
+  map.setTilt(45);
+
+  map.addListener("zoom_changed", () => {
+    const newZoom = map.getZoom()!;
+
+    if (newZoom < 19) {
+      map.setTilt(0);
+      map.setMapTypeId(originalMapTypeId);
+    }
+  });
+}
+
+// [END maps_store_locator]
+export { initMap };

--- a/samples/store-locator/src/style.scss
+++ b/samples/store-locator/src/style.scss
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'sass:meta'; // To enable @use via meta.load-css and keep comments in order
+
+/* [START maps_store_locator] */
+@include meta.load-css(
+  // TODO https://github.com/sass/dart-sass/issues/1033
+  "../../../shared/scss/sidebar.scss",
+  $with: ("sidebar-flex-basis": 5rem)
+);
+@include meta.load-css("../../../shared/scss/material-design-theme.scss");
+
+#sidebar {
+  flex-basis: 5rem; // override the default sidebar basis
+  flex-direction: column;
+}
+
+#search,
+.mdc-card {
+  margin-bottom: 1rem;
+}
+
+#search {
+  display: flex;
+  align-items: center;
+
+  .mdc-icon-button,
+  .mdc-text-field {
+    margin: 0 0.1rem 0 0;
+  }
+
+  .mdc-icon-button {
+    color: var(--mdc-theme-primary);
+  }
+
+  .mdc-text-field {
+    flex-grow: 1;
+  }
+}
+
+#cards {
+  height: calc(100% - 56px);
+  overflow: scroll;
+}
+
+#card-body,
+#card-header {
+  padding: 0 1rem;
+}
+
+/* [END maps_store_locator] */

--- a/samples/store-locator/stores.json
+++ b/samples/store-locator/stores.json
@@ -1,0 +1,538 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Googleplex"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.084123,
+          37.422015
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google NY"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.004698,
+          40.741961
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Ann Arbor"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -83.748548,
+          42.281289
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Atlanta"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -84.387388,
+          33.781486
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Boulder"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -105.276948,
+          40.018512
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Cambridge"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -71.083144,
+          42.362195
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Chicago"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -87.628746,
+          41.889245
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Dallas"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -96.816136,
+          32.925488
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Detroit"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -83.243009,
+          42.47672
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Irvine"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -117.860273,
+          33.659878
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Phoenix"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -111.92628,
+          33.411409
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Pittsburgh"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -79.946209,
+          40.44454
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Santa Monica"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.49484,
+          34.019339
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Kirkland"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.195868,
+          47.678292
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Seattle"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.352909,
+          47.6501
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Denver"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -104.89989,
+          39.627502
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Dublin"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -6.25,
+          53.330001
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Melbourne"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          144.957087,
+          -37.818429
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Sydney"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          151.203856,
+          -33.872002
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Brazil"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -46.691208,
+          -23.570123
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Canada"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -79.379311,
+          43.64642
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Denmark"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.569998,
+          55.679999
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Finland"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          24.934201,
+          60.173175
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google France"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          2.332899,
+          48.869199
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Germany"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.985265,
+          53.554051
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Bangalore"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          77.599986,
+          12.97034
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google New-Delhi"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          77.105141,
+          28.449676
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Hyderabad "
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          78.77903,
+          17.627331
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Mumbai"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          72.826437,
+          18.940854
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Italy"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.195978,
+          45.46381
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Japan"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          139.759997,
+          35.704704
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Korea"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          126.989997,
+          37.56
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Mexico"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -99.569998,
+          19.199999
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Netherlands"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          4.87754,
+          52.330522
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Norway"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.399998,
+          63.439998
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Spain"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.692995,
+          40.450316
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Sweden"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          18.074912,
+          59.339492
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Switzerland"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.532018,
+          47.367479
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Turkey"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          29.011706,
+          41.078017
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google London"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.146699,
+          51.494799
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Name": "Google Manchester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.243613,
+          53.477344
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When user clicks on a marker or store name in the list view, zoom in on that location and switch the map view to a 45-degree tilt hybrid map. When the user zooms back out for any reason, revert to the original map type. If 45-degree imagery is not available at the chosen location, 0-degree tilt imagery is displayed.

Rebase on updated master from original PR #685