### PR TITLE
fix: Add Roboto font family to CSS

### DIFF
--- a/dist/samples/place-search-pagination/iframe.html
+++ b/dist/samples/place-search-pagination/iframe.html
@@ -32,6 +32,7 @@
   #sidebar {
     display: flex;
     flex-direction: column;
+    font-family: "Roboto";
   }
 
   h2 {
@@ -54,7 +55,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    font-size: 1.25rem;
     cursor: pointer;
   }
 

--- a/dist/samples/place-search-pagination/index.html
+++ b/dist/samples/place-search-pagination/index.html
@@ -36,6 +36,7 @@
       #sidebar {
         display: flex;
         flex-direction: column;
+        font-family: "Roboto";
       }
 
       h2 {
@@ -58,7 +59,6 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
-        font-size: 1.25rem;
         cursor: pointer;
       }
 

--- a/dist/samples/place-search-pagination/inline.html
+++ b/dist/samples/place-search-pagination/inline.html
@@ -36,6 +36,7 @@
       #sidebar {
         display: flex;
         flex-direction: column;
+        font-family: "Roboto";
       }
 
       h2 {
@@ -58,7 +59,6 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
-        font-size: 1.25rem;
         cursor: pointer;
       }
 

--- a/dist/samples/place-search-pagination/style.css
+++ b/dist/samples/place-search-pagination/style.css
@@ -31,6 +31,7 @@ body {
 #sidebar {
   display: flex;
   flex-direction: column;
+  font-family: "Roboto";
 }
 
 h2 {
@@ -53,7 +54,6 @@ li {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  font-size: 1.25rem;
   cursor: pointer;
 }
 

--- a/samples/place-search-pagination/src/style.scss
+++ b/samples/place-search-pagination/src/style.scss
@@ -26,6 +26,7 @@
 #sidebar {
   display: flex;
   flex-direction: column;
+  font-family: "Roboto";
 }
 
 h2 {
@@ -46,7 +47,6 @@ li {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  font-size: 1.25rem;
   cursor: pointer;
 }
 li:nth-child(odd) {


### PR DESCRIPTION
Currently the paginated results display in a serif font, which detracts from the visual appearance. This change updates the example to use Roboto instead.

Fixes #866 🦕
