### PR TITLE
fix: hide scrollbar

### DIFF
--- a/dist/samples/playground.html
+++ b/dist/samples/playground.html
@@ -5,8 +5,15 @@
       href="https://fonts.googleapis.com/css?family=Material+Icons&display=block"
       rel="stylesheet"
     />
-  </head>
-  <body>
+    <style>
+      body {
+        scrollbar-width: none;
+      }
+      ::-webkit-scrollbar {
+        display: none;
+      }
+    </style>
     <script type="module" src="../index.js"></script>
-  </body>
+  </head>
+  <body></body>
 </html>

--- a/samples/index.html.njk
+++ b/samples/index.html.njk
@@ -4,9 +4,17 @@ permalink: /samples/playground.html
 <!DOCTYPE html>
 <html>
   <head>
-    <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">    
+    <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
+    <style>
+      body {
+        scrollbar-width: none;
+      }
+      ::-webkit-scrollbar {
+        display:none;
+      }
+    </style>
+    <script type="module" src="../index.js"></script>    
   </head>
   <body>
-    <script type="module" src="../index.js"></script>    
   </body>
 </html>


### PR DESCRIPTION
tl;dr This hides the vertical scrollbar which should never be necessary.

The scrollbar doesn't happen on the standalone page because it does not have a fixed height. It only shows up when embedded in an iframe or similar. In this case, there is communication between the iframe and the parent window to automatically adjust the height. However, this is not instantaneous and leads to a flash of the vertical scrollbar.
