### PR TITLE
Fixed advanced-markers-draggable code

### DIFF
--- a/dist/samples/advanced-markers-draggable/docs/index.js
+++ b/dist/samples/advanced-markers-draggable/docs/index.js
@@ -24,7 +24,7 @@ function initMap() {
     const position = draggableMarker.position;
 
     infoWindow.close();
-    infoWindow.setContent(`Pin dropped at: ${position.lat}, ${position.lng}`);
+    infoWindow.setContent(`Pin dropped at: ${position.lat()}, ${position.lng()}`);
     infoWindow.open(draggableMarker.map, draggableMarker);
   });
 }


### PR DESCRIPTION
The draggable marker example on https://developers.google.com/maps/documentation/javascript/advanced-markers/accessible-markers#make_a_marker_draggable is bugged, it prints `Pin dropped at: function(){return e}, function(){return f}`.