### PR TITLE
feat: Updates marker collision demo

### DIFF
--- a/samples/advanced-markers-collision/index.njk
+++ b/samples/advanced-markers-collision/index.njk
@@ -27,7 +27,11 @@
           </span>
         </div>
         <div class="mdc-select__menu mdc-menu mdc-menu-surface">
-          <ul class="mdc-list"></ul>
+          <ul class="mdc-list">
+            <li class="mdc-list-item" data-value="REQUIRED">Required</li>
+            <li class="mdc-list-item" data-value="REQUIRED_AND_HIDES_OPTIONAL">Required and hides optional</li>
+            <li class="mdc-list-item" data-value="OPTIONAL_AND_HIDES_LOWER_PRIORITY">Optional and hides lower priority</li>
+          </ul>
         </div>
       </div>
     </div>

--- a/samples/advanced-markers-collision/index.ts
+++ b/samples/advanced-markers-collision/index.ts
@@ -27,24 +27,6 @@ async function initMap(): Promise<void> {
     } as google.maps.MapOptions
   );
 
-  const menuList = document.querySelector(".mdc-list") as HTMLUListElement;
-
-  // Add the behaviors to the select options
-  for (const [key, value] of Object.entries(google.maps.CollisionBehavior)) {
-    const item = document.createElement("LI");
-
-    item.classList.add("mdc-list-item");
-    item.setAttribute("data-value", key);
-
-    const itemText = document.createElement("SPAN") as HTMLSpanElement;
-
-    itemText.classList.add("mdc-list-item__text");
-    itemText.innerText = value as string;
-
-    item.appendChild(itemText);
-    menuList.appendChild(item);
-  }
-
   // @ts-ignore
   const select = new mdc.select.MDCSelect(
     document.querySelector(".mdc-select") as HTMLElement


### PR DESCRIPTION
Updates the marker collision demo dropdown menu to use normal language rather than the JSAPI enum value, so that the demo can be used across all platforms. This change removes a function that generates the menu, and hard-codes the menu items in HTML. One side effect is that it slightly simplifies the code.

Fixes #1545  🦕
