### PR TITLE
chore: run tests on pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@
 
 name: e2e
 on:
-  pull-request:
+  pull_request:
     branches:
       - main
   push:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,16 +27,13 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  not_approved:
-    if: >-
-      github.event.review.state &&
-      github.event.review.state != 'approved'
-    run: |
-      echo "Skipping tests until PR is approved." >> $GITHUB_STEP_SUMMARY
-      stopMarker=$(uuidgen)
-      exit 1
   build:
-    if: "!contains(github.event.head_commit.message, 'chore: update dist folder')"
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' &&
+      !contains(github.event.head_commit.message, 'chore: update dist folder')) ||
+      (github.event_name == 'pull_request_review' &&
+      github.event.review.state != 'approved')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,9 @@
 
 name: e2e
 on:
+  pull-request:
+    branches:
+      - main
   push:
     branches-ignore:
       - master

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
       (github.event_name == 'push' &&
       !contains(github.event.head_commit.message, 'chore: update dist folder')) ||
       (github.event_name == 'pull_request_review' &&
-      github.event.review.state != 'approved')
+      github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,9 +14,10 @@
 
 name: e2e
 on:
-  pull_request:
+  pull_request_review:
     branches:
       - main
+    types: [submitted]
   push:
     branches-ignore:
       - master
@@ -26,6 +27,14 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  not_approved:
+    if: >-
+      github.event.review.state &&
+      github.event.review.state != 'approved'
+    run: |
+      echo "Skipping tests until PR is approved." >> $GITHUB_STEP_SUMMARY
+      stopMarker=$(uuidgen)
+      exit 1
   build:
     if: "!contains(github.event.head_commit.message, 'chore: update dist folder')"
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@
 
 name: Test
 on:
-  pull-request:
+  pull_request:
     branches:
       - main
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'pull_request_review' &&
-      github.event.review.state != 'approved')
+      github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [submitted]
   push:
     branches-ignore:
       - master
@@ -24,6 +25,14 @@ concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  not_approved:
+    if: >-
+      github.event.review.state &&
+      github.event.review.state != 'approved'
+    run: |
+      echo "Skipping tests until PR is approved." >> $GITHUB_STEP_SUMMARY
+      stopMarker=$(uuidgen)
+      exit 1
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@
 
 name: Test
 on:
-  pull_request:
+  pull_request_review:
     branches:
       - main
     types: [submitted]
@@ -25,15 +25,11 @@ concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  not_approved:
-    if: >-
-      github.event.review.state &&
-      github.event.review.state != 'approved'
-    run: |
-      echo "Skipping tests until PR is approved." >> $GITHUB_STEP_SUMMARY
-      stopMarker=$(uuidgen)
-      exit 1
   test:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_review' &&
+      github.event.review.state != 'approved')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,13 @@
 
 name: Test
 on:
+  pull-request:
+    branches:
+      - main
   push:
     branches-ignore:
       - master
-concurrency: 
+concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 jobs:


### PR DESCRIPTION
The test workflows are not running on community-contributed pull requests, since they're only configured to run on push (available to users with write permissions).

This pull request adds a trigger for tests to run on pull requests that target the `main` branch.