### PR TITLE
fix: Adds ts-ignore comments for pre-release features

### DIFF
--- a/samples/boundaries-text-search/index.ts
+++ b/samples/boundaries-text-search/index.ts
@@ -36,6 +36,7 @@ async function findBoundary() {
     };
 
     const { Place } = await google.maps.importLibrary("places") as google.maps.PlacesLibrary;
+    //@ts-ignore
     const { places } = await Place.searchByText(request);
 
     if (places.length) {

--- a/samples/place-autocomplete-element/index.ts
+++ b/samples/place-autocomplete-element/index.ts
@@ -13,7 +13,9 @@ async function initMap(): Promise<void> {
         google.maps.importLibrary("places"),
     ]);
     // Create the input HTML element, and append it.
+    //@ts-ignore
     const placeAutocomplete = new google.maps.places.PlaceAutocompleteElement();
+    //@ts-ignore
     document.body.appendChild(placeAutocomplete);
     // [END maps_place_autocomplete_element_add]
 
@@ -28,6 +30,7 @@ async function initMap(): Promise<void> {
 
     // [START maps_place_autocomplete_element_listener]
     // Add the gmp-placeselect listener, and display the results.
+    //@ts-ignore
     placeAutocomplete.addEventListener('gmp-placeselect', async ({ place }) => {
         await place.fetchFields({ fields: ['displayName', 'formattedAddress', 'location'] });
 

--- a/samples/place-autocomplete-map/index.ts
+++ b/samples/place-autocomplete-map/index.ts
@@ -26,9 +26,11 @@ async function initMap(): Promise<void> {
     // [START maps_place_autocomplete_map_add]
     //@ts-ignore
     const placeAutocomplete = new google.maps.places.PlaceAutocompleteElement();
+    //@ts-ignore
     placeAutocomplete.id = 'place-autocomplete-input';
 
     const card = document.getElementById('place-autocomplete-card') as HTMLElement;
+    //@ts-ignore
     card.appendChild(placeAutocomplete);
     map.controls[google.maps.ControlPosition.TOP_LEFT].push(card);
     // [END maps_place_autocomplete_map_add]
@@ -42,6 +44,7 @@ async function initMap(): Promise<void> {
 
     // [START maps_place_autocomplete_map_listener]
     // Add the gmp-placeselect listener, and display the results on the map.
+    //@ts-ignore
     placeAutocomplete.addEventListener('gmp-placeselect', async ({ place }) => {
         await place.fetchFields({ fields: ['displayName', 'formattedAddress', 'location'] });
 


### PR DESCRIPTION
This PR adds `//@ts-ignore` comments to files for some pre-release example maps, for which certain lines were resulting in `test:jest` errors. These errors do NOT impact production content, this is done for the sake of preventing build errors of any kind.

Fixes #1624 🦕
