### PR TITLE
fix: Change height style to 400px

### DIFF
--- a/samples/web-components-events/style.scss
+++ b/samples/web-components-events/style.scss
@@ -10,7 +10,7 @@
 @include meta.load-css("../../shared/scss/default.scss");
 
 gmp-map {
-    height: 500px;
+    height: 400px;
 }
 
 /* [END maps_web_components_events] */

--- a/samples/web-components-map/style.scss
+++ b/samples/web-components-map/style.scss
@@ -10,7 +10,7 @@
 @include meta.load-css("../../shared/scss/default.scss");
 
 gmp-map {
-    height: 500px;
+    height: 400px;
 }
 
 /* [END maps_web_components_map] */

--- a/samples/web-components-markers/style.scss
+++ b/samples/web-components-markers/style.scss
@@ -10,7 +10,7 @@
  @include meta.load-css("../../shared/scss/default.scss");
  
  gmp-map {
-     height: 500px;
+     height: 400px;
  }
  
  /* [END maps_web_components_markers] */


### PR DESCRIPTION
This will prevent subscrolling on the page, since example maps are set to 400px height by default.