### PR TITLE
fix: Changes "query" to "textQuery"

### DIFF
--- a/samples/place-search/index.ts
+++ b/samples/place-search/index.ts
@@ -24,7 +24,7 @@ function initMap(): void {
   });
 
   const request = {
-    textQuery: "Museum of Contemporary Art Australia",
+    query: "Museum of Contemporary Art Australia",
     fields: ["name", "geometry"],
   };
 

--- a/samples/place-search/index.ts
+++ b/samples/place-search/index.ts
@@ -24,7 +24,7 @@ function initMap(): void {
   });
 
   const request = {
-    query: "Museum of Contemporary Art Australia",
+    textQuery: "Museum of Contemporary Art Australia",
     fields: ["name", "geometry"],
   };
 

--- a/samples/place-text-search/index.ts
+++ b/samples/place-text-search/index.ts
@@ -29,7 +29,7 @@ async function findPlaces() {
     //@ts-ignore
     const { AdvancedMarkerElement } = await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
     const request = {
-        query: 'Tacos in Mountain View',
+        textQuery: 'Tacos in Mountain View',
         fields: ['displayName', 'location', 'businessStatus'],
         includedType: 'restaurant',
         isOpenNow: true,


### PR DESCRIPTION
This changes the "query" parameter to "textQuery" for the Place Search example.

Fixes #<issue_number_goes_here> 🦕
