### PR TITLE
fix: Adds gmpClickable attribute.

### DIFF
--- a/samples/advanced-markers-accessibility/index.ts
+++ b/samples/advanced-markers-accessibility/index.ts
@@ -56,6 +56,7 @@ async function initMap() {
             map,
             title: `${i + 1}. ${title}`,
             content: pin.element,
+            gmpClickable: true,
         });
 
         // Add a click listener for each marker, and set up the info window.

--- a/samples/web-components-events/index.njk
+++ b/samples/web-components-events/index.njk
@@ -6,7 +6,7 @@
 -->
 {% extends '../../src/_includes/layout.njk'%} {% block html %}
 <gmp-map id="marker-click-event-example" center="43.4142989,-124.2301242" zoom="4" map-id="DEMO_MAP_ID">
-  <gmp-advanced-marker position="37.4220656,-122.0840897" title="Mountain View, CA"></gmp-advanced-marker>
-  <gmp-advanced-marker position="47.648994,-122.3503845" title="Seattle, WA"></gmp-advanced-marker>
+  <gmp-advanced-marker position="37.4220656,-122.0840897" title="Mountain View, CA" gmp-clickable></gmp-advanced-marker>
+  <gmp-advanced-marker position="47.648994,-122.3503845" title="Seattle, WA" gmp-clickable></gmp-advanced-marker>
 </gmp-map>
 {% endblock %}


### PR DESCRIPTION
Adds the gmp-clickable attribute to gmp-advanced-marker elements for two examples.

Fixes https://github.com/googlemaps/js-samples/issues/1646 🦕
