### PR TITLE
fix: Updates version to beta

### DIFF
--- a/samples/place-autocomplete-map/place-autocomplete-map.json
+++ b/samples/place-autocomplete-map/place-autocomplete-map.json
@@ -1,6 +1,6 @@
 {
     "title": "Place Autocomplete map",
-    "version": "alpha",
+    "version": "beta",
     "dynamic_import": "true",
     "tag": "place_autocomplete_map",
     "name": "place-autocomplete-map",


### PR DESCRIPTION
Updates version from "alpha" to "beta" for place-autocomplete-map and place-autocomplete-element, as they are now on beta channel.
