### PR TITLE
fix: Changes alpha to beta for ac examples.

### DIFF
--- a/samples/place-autocomplete-element/place-autocomplete-element.json
+++ b/samples/place-autocomplete-element/place-autocomplete-element.json
@@ -1,6 +1,6 @@
 {
     "title": "Place Autocomplete element",
-    "version": "alpha",
+    "version": "beta",
     "dynamic_import": "true",
     "tag": "place_autocomplete_element",
     "name": "place-autocomplete-element",

--- a/samples/place-autocomplete-map/place-autocomplete-map.json
+++ b/samples/place-autocomplete-map/place-autocomplete-map.json
@@ -1,6 +1,6 @@
 {
     "title": "Place Autocomplete map",
-    "version": "alpha",
+    "version": "beta",
     "dynamic_import": "true",
     "tag": "place_autocomplete_map",
     "name": "place-autocomplete-map",


### PR DESCRIPTION
Updates "alpha" to "beta" in config for place-autocomplete-element, and place-autocomplete-map

Fixes #1665 🦕
