### PR TITLE
fix: Adds style attribute to prevent size changes

### DIFF
--- a/samples/place-autocomplete-map/style.scss
+++ b/samples/place-autocomplete-map/style.scss
@@ -20,8 +20,8 @@
   font-weight: bold;
 }
 
-#place-autocomplete {
-  width: 250px;
+gmp-place-autocomplete {
+  width: 300px;
 }
 
 #infowindow-content .title {


### PR DESCRIPTION
Adds a width attribute to gmp-place-autocomplete to prevent size changes on user input.

Fixes #1671  🦕
