### PR TITLE
fix: Fixes broken infowindow on event handler.

### DIFF
--- a/samples/advanced-markers-draggable/index.ts
+++ b/samples/advanced-markers-draggable/index.ts
@@ -29,7 +29,7 @@
     draggableMarker.addListener('dragend', (event) => {
         const position = draggableMarker.position as google.maps.LatLng;
         infoWindow.close();
-        infoWindow.setContent(`Pin dropped at: ${position.lat()}, ${position.lng()}`);
+        infoWindow.setContent(`Pin dropped at: ${position.lat}, ${position.lng}`);
         infoWindow.open(draggableMarker.map, draggableMarker);
     });
     


### PR DESCRIPTION
This fix removes weird parenthesis from position values, which appear to have broken the infowindow functionality for this sample.

Fixes #<1688>🦕
