### PR TITLE
fix: Removes exclusion tags, changes to use DEMO_MAP_ID

### DIFF
--- a/samples/place-nearby-search/index.ts
+++ b/samples/place-nearby-search/index.ts
@@ -62,7 +62,7 @@ async function nearbySearch() {
                 title: place.displayName,
             });
 
-            bounds.extend(place.location);
+            bounds.extend(place.location as google.maps.LatLng);
             console.log(place);
         });
     

--- a/samples/place-text-search/index.ts
+++ b/samples/place-text-search/index.ts
@@ -57,7 +57,7 @@ async function findPlaces() {
                 title: place.displayName,
             });
 
-            bounds.extend(place.location);
+            bounds.extend(place.location as google.maps.LatLng);
             console.log(place);
         });
 

--- a/samples/place-text-search/index.ts
+++ b/samples/place-text-search/index.ts
@@ -16,9 +16,7 @@ async function initMap() {
     map = new Map(document.getElementById('map') as HTMLElement, {
         center: center,
         zoom: 11,
-        // [START_EXCLUDE]
-        mapId: '4504f8b37365c3d0',
-        // [END_EXCLUDE]
+        mapId: 'DEMO_MAP_ID',
     });
 
     findPlaces();


### PR DESCRIPTION
Problem: The example map uses a custom reduced-POI map ID. At one point a request was made to obscure the map ID parameter to avoid exposing the custom map ID. This is not ideal since the map ID parameter is required, and must be exposed. Visually users will not see the parameter, and that's a problem. The example works when users link to JS Fiddle using the buttons, but if the code is copied and pasted it won't work. 

Solution: Get rid of the custom map ID and use DEMO_MAP_ID; remove the exclude tag which hides the needed map ID parameter.

This change also adds a couple of type declarations that were missing for some reason.

This fix is in response to b/316906523 🦕
