### PR TITLE
feat: Adds example map for marker accessibility using gmp-map.

### DIFF
--- a/samples/advanced-markers-accessibility/index.ts
+++ b/samples/advanced-markers-accessibility/index.ts
@@ -13,7 +13,7 @@ async function initMap() {
     const map = new Map(document.getElementById("map") as HTMLElement, {
         zoom: 12,
         center: { lat: 34.84555, lng: -111.8035 },
-        mapId: '4504f8b37365c3d0',
+        mapId: 'DEMO_MAP_ID',
     });
 
     // Set LatLng and title text for the markers. The first marker (Boynton Pass)
@@ -49,22 +49,25 @@ async function initMap() {
     tourStops.forEach(({position, title}, i) => {
         const pin = new PinElement({
             glyph: `${i + 1}`,
+            scale: 1.5,
         });
-
+        // [START maps_advanced_markers_accessibility_marker]
         const marker = new AdvancedMarkerElement({
             position,
             map,
             title: `${i + 1}. ${title}`,
             content: pin.element,
         });
+        // [END maps_advanced_markers_accessibility_marker]
 
-        // Add a click listener for each marker, and set up the info window.
-        marker.addListener('click', ({ domEvent, latLng }) => {
-            const { target } = domEvent;
+        // Add event handling code for markers.
+        // [START maps_advanced_markers_accessibility_event_listener]
+        marker.addEventListener('gmp-click', () => {
             infoWindow.close();
             infoWindow.setContent(marker.title);
             infoWindow.open(marker.map, marker);
         });
+        // [END maps_advanced_markers_accessibility_event_listener]
     });
 }
 

--- a/samples/advanced-markers-simple/index.ts
+++ b/samples/advanced-markers-simple/index.ts
@@ -5,7 +5,6 @@
  */
 
 // [START maps_advanced_markers_simple]
-// [START maps_advanced_markers_simple_snippet]
 async function initMap() {
     // Request needed libraries.
     const { Map } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
@@ -16,13 +15,14 @@ async function initMap() {
         zoom: 14,
         mapId: '4504f8b37365c3d0',
     });
-
+    // [START maps_advanced_markers_simple_marker]
     const marker = new AdvancedMarkerElement({
         map,
         position: { lat: 37.4239163, lng: -122.0947209 },
     });
+    // [END maps_advanced_markers_simple_marker]
 }
-// [END maps_advanced_markers_simple_snippet]
+
 initMap();
 // [END maps_advanced_markers_simple]
 export { };

--- a/samples/web-components-accessibility/index.njk
+++ b/samples/web-components-accessibility/index.njk
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!--
+ @license
+ Copyright 2019 Google LLC. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+{% extends '../../src/_includes/layout.njk'%} {% block html %}
+<gmp-map center="34.84555, -111.8035" zoom="12" map-id="DEMO_MAP_ID">
+    <!-- START maps_web_components_events_clickable -->
+    <gmp-advanced-marker position="34.8791806, -111.8265049" title="Boynton Pass" gmp-clickable></gmp-advanced-marker>
+    <!-- END maps_web_components_events_clickable -->
+    <gmp-advanced-marker position="34.8559195, -111.7988186" title="Airport Mesa" gmp-clickable></gmp-advanced-marker>
+    <gmp-advanced-marker position="34.832149, -111.7695277" title="Chapel of the Holy Cross" gmp-clickable></gmp-advanced-marker>
+    <gmp-advanced-marker position="34.823736, -111.8001857" title="Red Rock Crossing" gmp-clickable></gmp-advanced-marker>
+    <gmp-advanced-marker position="34.800326, -111.7665047" title="Bell Rock" gmp-clickable></gmp-advanced-marker>
+</gmp-map>
+{% endblock %}

--- a/samples/web-components-accessibility/index.ts
+++ b/samples/web-components-accessibility/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// [START maps_web_components_accessibility]
+async function initMap(): Promise<void> {
+    const { InfoWindow } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
+    const { PinElement } = await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
+    console.log('Maps JavaScript API loaded.');
+
+    // [START maps_web_components_accessibility_query]
+    // Return an array of markers.
+    const advancedMarkers = [...document.querySelectorAll('gmp-advanced-marker')];
+    // [END maps_web_components_accessibility_query]
+
+    // [START maps_web_components_accessibility_iterate]
+    // Create a shared info window.
+    let infoWindow = new InfoWindow();
+
+    for (let i = 0; i < advancedMarkers.length; i++) {
+        const marker = advancedMarkers[i] as google.maps.marker.AdvancedMarkerElement;
+        const pin = new PinElement({
+            glyph: `${i + 1}`,
+            scale: 1.5,
+        });
+
+        marker.appendChild(pin.element);
+        marker.addEventListener('gmp-click', () => {
+            infoWindow.close();
+            infoWindow.setContent(marker.title);
+            infoWindow.open(marker.map, marker);
+        });
+    }
+    // [END maps_web_components_accessibility_iterate]
+}
+
+initMap();
+// [END maps_web_components_accessibility]
+export { };

--- a/samples/web-components-accessibility/style.scss
+++ b/samples/web-components-accessibility/style.scss
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ @use 'sass:meta'; // To enable @use via meta.load-css and keep comments in order
+
+ /* [START maps_web_components_accessibility] */
+ @include meta.load-css("../../shared/scss/default.scss");
+ 
+ gmp-map {
+     height: 400px;
+ }
+ 
+ /* [END maps_web_components_accessibility] */
+ 

--- a/samples/web-components-accessibility/web-components-accessibility.json
+++ b/samples/web-components-accessibility/web-components-accessibility.json
@@ -1,0 +1,13 @@
+{
+    "title": "Advanced Marker Accessibility with web components",
+    "dynamic_import": "true",
+    "version": "beta",
+    "tag": "web_components_accessibility",
+    "name": "web-components-accessibility",
+    "pagination": {
+        "data": "mode",
+        "size": 1,
+        "alias": "mode"
+    },
+    "permalink": "samples/{{ page.fileSlug }}/{{mode}}/{% if mode == 'jsfiddle' %}demo{% else %}index{% endif %}.{{ page.outputFileExtension }}"
+}

--- a/samples/web-components-events/index.njk
+++ b/samples/web-components-events/index.njk
@@ -5,8 +5,10 @@
  SPDX-License-Identifier: Apache-2.0
 -->
 {% extends '../../src/_includes/layout.njk'%} {% block html %}
-<gmp-map id="marker-click-event-example" center="43.4142989,-124.2301242" zoom="4" map-id="DEMO_MAP_ID">
+<gmp-map center="43.4142989,-124.2301242" zoom="4" map-id="DEMO_MAP_ID">
+  <!-- START maps_web_components_events_clickable-->
   <gmp-advanced-marker position="37.4220656,-122.0840897" title="Mountain View, CA" gmp-clickable></gmp-advanced-marker>
+  <!-- END maps_web_components_events_clickable-->
   <gmp-advanced-marker position="47.648994,-122.3503845" title="Seattle, WA" gmp-clickable></gmp-advanced-marker>
 </gmp-map>
 {% endblock %}

--- a/samples/web-components-events/index.ts
+++ b/samples/web-components-events/index.ts
@@ -7,27 +7,21 @@
 // [START maps_web_components_events]
 // This example adds a map using web components.
 async function initMap(): Promise<void> {
-  const { Map } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
-  const { AdvancedMarkerElement } = await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
-
+  const { InfoWindow } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
+  await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
   console.log('Maps JavaScript API loaded.');
 
-  const advancedMarkers = document.querySelectorAll("#marker-click-event-example gmp-advanced-marker");
-  
-  for (const advancedMarker of advancedMarkers) {
+  // Return an array of markers.
+  const advancedMarkers = [...document.querySelectorAll('gmp-advanced-marker')];
 
-    customElements.whenDefined(advancedMarker.localName).then(async () => {
-      advancedMarker.addEventListener('gmp-click', async () => {
+  let infoWindow = new InfoWindow();
 
-        const infoWindow = new google.maps.InfoWindow({
-          //@ts-ignore
-          content: advancedMarker.title,
-        });
-        infoWindow.open({
-          //@ts-ignore
-          anchor: advancedMarker
-        });
-      });
+  for (let i = 0; i < advancedMarkers.length; i++) {
+    const marker = advancedMarkers[i] as google.maps.marker.AdvancedMarkerElement;
+    marker.addEventListener('gmp-click', () => {
+      infoWindow.close();
+      infoWindow.setContent(marker.title);
+      infoWindow.open(marker.map, marker);
     });
   }
 }

--- a/samples/web-components-map/index.ts
+++ b/samples/web-components-map/index.ts
@@ -7,7 +7,7 @@
 // [START maps_web_components_map]
 // This example adds a map using web components.
 async function initMap(): Promise<void> {
-    const { Map } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
+    await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
     console.log('Maps JavaScript API loaded.');
 }
 

--- a/samples/web-components-markers/index.ts
+++ b/samples/web-components-markers/index.ts
@@ -5,10 +5,10 @@
  */
 
 // [START maps_web_components_markers]
-// This example adds a map with markers, using web components.
+// Add libraries and log a message.
 async function initMap(): Promise<void> {
-    const { Map } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
-    const { AdvancedMarkerElement } = await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
+    await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
+    await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
 
     console.log('Maps JavaScript API loaded.');
 }


### PR DESCRIPTION
This change adds a new map to demonstrate marker accessibility on a map built using the gmp-map element. It also:
- Adds region tags to the simple markers example.
- Replaces a custom map ID with DEMO_MAP_ID.

rawr 🦕
