### PR TITLE
fix: Remove default style from SCSS

### DIFF
--- a/samples/web-components-map/style.scss
+++ b/samples/web-components-map/style.scss
@@ -7,5 +7,4 @@
 @use 'sass:meta'; // To enable @use via meta.load-css and keep comments in order
 
 /* [START maps_web_components_map] */
-@include meta.load-css("../../shared/scss/default.scss");
 /* [END maps_web_components_map] */


### PR DESCRIPTION
This is because we moved the CSS to the HTML in a previous PR, and no longer need the default markup.

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
