### PR TITLE
fix: Adds a conditional to the `callback` parameter

### DIFF
--- a/samples/web-components-map/web-components-map.json
+++ b/samples/web-components-map/web-components-map.json
@@ -1,6 +1,5 @@
 {
     "title": "Add a Map using HTML",
-    "callback": "initMap",
     "libraries": [],
     "version": "beta",
     "tag": "web_components_map",

--- a/samples/web-components-markers/web-components-markers.json
+++ b/samples/web-components-markers/web-components-markers.json
@@ -1,6 +1,5 @@
 {
     "title": "Add a Map with Markers using HTML",
-    "callback": "initMap",
     "libraries": ["marker"],
     "version": "beta",
     "tag": "web_components_markers",

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -47,7 +47,7 @@
       for more information.
       -->
       <script 
-        src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_MAPS_API_KEY}}&callback={{ callback }}{% if libraries|length %}&libraries={{ libraries }}{% endif %}&v={{ version }}{% if language %}&language={{ language }}{% endif %}{% if region %}&region={{ region }}{% endif %}" defer></script>
+        src="https://maps.googleapis.com/maps/api/js?key={{GOOGLE_MAPS_API_KEY}}{% if callback %}&callback={{ callback }}{% endif %}{% if libraries|length %}&libraries={{ libraries }}{% endif %}&v={{ version }}{% if language %}&language={{ language }}{% endif %}{% if region %}&region={{ region }}{% endif %}" defer></script>
     {% endif -%}
   {% endblock %}   
   </body>


### PR DESCRIPTION
Maps created using custom HTML elements (aka Web Components) do not require the `callback` parameter. This change introduces a conditional to the template, so that if `callback` is omitted in the configuration file, nothing will appear in the bootstrap. Removes the `callback` parameter from the two affected example maps.

Rawr! 🦕
