### PR TITLE
fix: Update index.ts to include MarkerClusterer import in region

### DIFF
--- a/samples/marker-clustering/index.ts
+++ b/samples/marker-clustering/index.ts
@@ -3,9 +3,9 @@
  * Copyright 2019 Google LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+// [START maps_marker_clustering]
 import { MarkerClusterer } from "@googlemaps/markerclusterer";
 
-// [START maps_marker_clustering]
 async function initMap() {
   // Request needed libraries.
   const { Map, InfoWindow } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;


### PR DESCRIPTION
The MarkerClusterer import was left out of all regions, causing some users to ask "whaaaat???". This change moves the vital import statement back into the region for the code example so everyone can see it and no, you are NOT crazy.
🦕🦕🦕🦕🦕🦕🦕🦕
