### PR TITLE
fix: manually increments maps dependency; adds renderingtype

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@googlemaps/three": "^4.0.13",
     "@playwright/test": "^1.44.0",
     "@types/geojson": "^7946.0.14",
-    "@types/google.maps": "^3.53.5",
+    "@types/google.maps": "^3.58.2",
     "@types/google.visualization": "0.0.73",
     "@types/jest": "^29.5.6",
     "@types/react": "^18.3.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@googlemaps/three": "^4.0.13",
     "@playwright/test": "^1.44.0",
     "@types/geojson": "^7946.0.14",
-    "@types/google.maps": "^3.58.2",
+    "@types/google.maps": "^3.58.5a",
     "@types/google.visualization": "0.0.73",
     "@types/jest": "^29.5.6",
     "@types/react": "^18.3.3",

--- a/samples/add-map/index.ts
+++ b/samples/add-map/index.ts
@@ -14,7 +14,7 @@ async function initMap(): Promise<void> {
 
   // Request needed libraries.
   //@ts-ignore
-  const { Map } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
+  const { Map, RenderingType } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
   const { AdvancedMarkerElement } = await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
 
   // The map, centered at Uluru
@@ -24,6 +24,7 @@ async function initMap(): Promise<void> {
       zoom: 4,
       center: position,
       mapId: 'DEMO_MAP_ID',
+      renderingType: RenderingType.VECTOR,
     }
   );
   // [END maps_add_map_instantiate_map]


### PR DESCRIPTION
This change is twofold:
- It manually increments the google.maps type.
- It adds renderingType to add-map example.
This is an attempt to get the renderingType change to be buildable. The underlying issue is that dependabot cannot run due to the 11ty ESM issue which is still not fixed. This fix is not a long-term solution.
🦕🦕🦕
