### PR TITLE
fix: Moves Place class declaration to avoid confusing pattern.

### DIFF
--- a/samples/place-class/index.ts
+++ b/samples/place-class/index.ts
@@ -10,7 +10,6 @@ let centerCoordinates = { lat: 37.4161493, lng: -122.0812166 };
 
 async function initMap() {
     const { Map } = await google.maps.importLibrary("maps") as google.maps.MapsLibrary;
-    const { Place } =  await google.maps.importLibrary("places") as google.maps.PlacesLibrary;
 
     map = new Map(document.getElementById('map') as HTMLElement, {
         center: centerCoordinates,
@@ -20,11 +19,12 @@ async function initMap() {
         // [END_EXCLUDE]
     });
 
-    getPlaceDetails(Place);
+    getPlaceDetails();
 }
 
 // [START maps_place_class_fetchfields]
-async function getPlaceDetails(Place) {
+async function getPlaceDetails() {
+    const { Place } =  await google.maps.importLibrary("places") as google.maps.PlacesLibrary;
     const { AdvancedMarkerElement } = await google.maps.importLibrary("marker") as google.maps.MarkerLibrary;
     // Use place ID to create a new Place instance.
     const place = new Place({


### PR DESCRIPTION
Just a simple small change to move the Place class declaration into the function that's using it, to avoid using the pattern of passing Place as a function parameter.
🦕 🦕 🦕 🦕 🦕 🦕 🦕
